### PR TITLE
fix(audit): order provider auto-configurations after their Boot count…

### DIFF
--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-kafka/src/main/java/ch/nexsol/gateway/audit/kafka/autoconfigure/KafkaAuditAutoConfiguration.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-kafka/src/main/java/ch/nexsol/gateway/audit/kafka/autoconfigure/KafkaAuditAutoConfiguration.java
@@ -29,15 +29,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.KafkaTemplate;
 
 /**
  * Registers the Kafka {@link AuditEventPublisher} when {@code audit.provider=kafka} and a
- * {@link KafkaTemplate} is available. Ordered before the core auto-configuration so its
- * publisher wins over the default one.
+ * {@link KafkaTemplate} is available. Ordered after {@link KafkaAutoConfiguration} so the
+ * auto-configured template is already defined, and before the core auto-configuration so
+ * its publisher wins over the default one.
  */
-@AutoConfiguration(before = AuditAutoConfiguration.class)
+@AutoConfiguration(after = KafkaAutoConfiguration.class, before = AuditAutoConfiguration.class)
 @ConditionalOnClass(KafkaTemplate.class)
 @ConditionalOnProperty(name = "spring.cloud.gateway.server.webflux.audit.provider", havingValue = "kafka")
 public class KafkaAuditAutoConfiguration {

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-kafka/src/test/java/ch/nexsol/gateway/audit/kafka/autoconfigure/KafkaAuditAutoConfigurationTests.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-kafka/src/test/java/ch/nexsol/gateway/audit/kafka/autoconfigure/KafkaAuditAutoConfigurationTests.java
@@ -24,18 +24,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 class KafkaAuditAutoConfigurationTests {
 
 	private final ApplicationContextRunner runner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(AuditAutoConfiguration.class, KafkaAuditAutoConfiguration.class))
-		.withBean(ObjectMapper.class)
-		.withBean(KafkaTemplate.class, () -> mock(KafkaTemplate.class));
+		.withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class, AuditAutoConfiguration.class,
+				KafkaAuditAutoConfiguration.class))
+		.withBean(ObjectMapper.class);
 
 	@Test
 	void registersKafkaPublisherWhenSelected() {

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/pom.xml
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/pom.xml
@@ -32,6 +32,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/src/main/java/ch/nexsol/gateway/audit/r2dbc/autoconfigure/R2dbcAuditAutoConfiguration.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/src/main/java/ch/nexsol/gateway/audit/r2dbc/autoconfigure/R2dbcAuditAutoConfiguration.java
@@ -29,15 +29,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.r2dbc.core.DatabaseClient;
 
 /**
  * Registers the R2DBC {@link AuditEventPublisher} when {@code audit.provider=r2dbc} and a
- * {@link DatabaseClient} is available. Ordered before the core auto-configuration so its
- * publisher wins over the default one.
+ * {@link DatabaseClient} is available. Ordered after {@link R2dbcAutoConfiguration} so
+ * the auto-configured client is already defined, and before the core auto-configuration
+ * so its publisher wins over the default one.
  */
-@AutoConfiguration(before = AuditAutoConfiguration.class)
+@AutoConfiguration(after = R2dbcAutoConfiguration.class, before = AuditAutoConfiguration.class)
 @ConditionalOnClass(DatabaseClient.class)
 @ConditionalOnProperty(name = "spring.cloud.gateway.server.webflux.audit.provider", havingValue = "r2dbc")
 public class R2dbcAuditAutoConfiguration {

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/src/test/java/ch/nexsol/gateway/audit/r2dbc/autoconfigure/R2dbcAuditAutoConfigurationTests.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-r2dbc/src/test/java/ch/nexsol/gateway/audit/r2dbc/autoconfigure/R2dbcAuditAutoConfigurationTests.java
@@ -24,18 +24,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.r2dbc.core.DatabaseClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 class R2dbcAuditAutoConfigurationTests {
 
 	private final ApplicationContextRunner runner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(AuditAutoConfiguration.class, R2dbcAuditAutoConfiguration.class))
-		.withBean(ObjectMapper.class)
-		.withBean(DatabaseClient.class, () -> mock(DatabaseClient.class));
+		.withConfiguration(AutoConfigurations.of(R2dbcAutoConfiguration.class, AuditAutoConfiguration.class,
+				R2dbcAuditAutoConfiguration.class))
+		.withPropertyValues("spring.r2dbc.url=r2dbc:h2:mem:///audit")
+		.withBean(ObjectMapper.class);
 
 	@Test
 	void registersR2dbcPublisherWhenSelected() {

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-redis/src/main/java/ch/nexsol/gateway/audit/redis/autoconfigure/RedisAuditAutoConfiguration.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-redis/src/main/java/ch/nexsol/gateway/audit/redis/autoconfigure/RedisAuditAutoConfiguration.java
@@ -29,15 +29,18 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 
 /**
  * Registers the Redis {@link AuditEventPublisher} when {@code audit.provider=redis} and a
- * {@link ReactiveStringRedisTemplate} is available. Ordered before the core
- * auto-configuration so its publisher wins over the default one.
+ * {@link ReactiveStringRedisTemplate} is available. Ordered after
+ * {@link DataRedisReactiveAutoConfiguration} so the auto-configured template is already
+ * defined, and before the core auto-configuration so its publisher wins over the default
+ * one.
  */
-@AutoConfiguration(before = AuditAutoConfiguration.class)
+@AutoConfiguration(after = DataRedisReactiveAutoConfiguration.class, before = AuditAutoConfiguration.class)
 @ConditionalOnClass(ReactiveStringRedisTemplate.class)
 @ConditionalOnProperty(name = "spring.cloud.gateway.server.webflux.audit.provider", havingValue = "redis")
 public class RedisAuditAutoConfiguration {

--- a/spring-cloud-gateway-audit/spring-cloud-gateway-audit-redis/src/test/java/ch/nexsol/gateway/audit/redis/autoconfigure/RedisAuditAutoConfigurationTests.java
+++ b/spring-cloud-gateway-audit/spring-cloud-gateway-audit-redis/src/test/java/ch/nexsol/gateway/audit/redis/autoconfigure/RedisAuditAutoConfigurationTests.java
@@ -24,8 +24,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -33,9 +34,10 @@ import static org.mockito.Mockito.mock;
 class RedisAuditAutoConfigurationTests {
 
 	private final ApplicationContextRunner runner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(AuditAutoConfiguration.class, RedisAuditAutoConfiguration.class))
+		.withConfiguration(AutoConfigurations.of(DataRedisReactiveAutoConfiguration.class, AuditAutoConfiguration.class,
+				RedisAuditAutoConfiguration.class))
 		.withBean(ObjectMapper.class)
-		.withBean(ReactiveStringRedisTemplate.class, () -> mock(ReactiveStringRedisTemplate.class));
+		.withBean(ReactiveRedisConnectionFactory.class, () -> mock(ReactiveRedisConnectionFactory.class));
 
 	@Test
 	void registersRedisPublisherWhenSelected() {


### PR DESCRIPTION
…erparts

The Kafka, Redis and R2DBC audit auto-configurations only declared `before = AuditAutoConfiguration`. With no ordering relation to the Boot auto-configuration that defines the underlying template, the sort fell back to class-name order, so `ch.nexsol...` ran before
`org.springframework.boot...` and the `@ConditionalOnSingleCandidate` check was evaluated while the bean definition did not exist yet. The provider publisher was never registered and auditing silently fell back to `DefaultAuditEventPublisher`.

Add the missing `after` relation to `KafkaAutoConfiguration`, `DataRedisReactiveAutoConfiguration` and `R2dbcAutoConfiguration`.

The tests could not catch this: they registered the template through `withBean`, which always applies before any auto-configuration and therefore never exercised the ordering. They now run the real Boot auto-configurations. R2DBC additionally needs a driver on the test classpath, since `R2dbcAutoConfiguration` is `@ConditionalOnResource` on the R2DBC SPI service file, hence the test-scoped `r2dbc-h2` dependency.