### PR TITLE
feat(routes-configserver): add Config Server route source + generaliz…

### DIFF
--- a/spring-cloud-gateway-routes/README.md
+++ b/spring-cloud-gateway-routes/README.md
@@ -11,6 +11,7 @@ the sources can be combined freely.
 | [spring-cloud-gateway-routes-core](spring-cloud-gateway-routes-core) | Shared caching/refresh locator infrastructure | — |
 | [spring-cloud-gateway-routes-database](spring-cloud-gateway-routes-database/README.md) | Database (R2DBC) with a light GUI | read/write (CRUD + UI) |
 | [spring-cloud-gateway-routes-files](spring-cloud-gateway-routes-files/README.md) | JSON/YAML files (GitOps / CI pipelines) | read-only |
+| [spring-cloud-gateway-routes-configserver](spring-cloud-gateway-routes-configserver/README.md) | JSON/YAML files served by Spring Cloud Config Server | read-only |
 | [spring-cloud-gateway-routes-openapi](spring-cloud-gateway-routes-openapi/README.md) | OpenAPI contract | read-only |
 | [spring-cloud-gateway-routes-security](spring-cloud-gateway-routes-security/README.md) | Route metadata (`public`) → Spring Security | cross-cutting |
 
@@ -33,3 +34,25 @@ Add the sub-module matching your source. Each is independently activated by its 
     <version>${spring-cloud-gateway-plugins.version}</version>
 </dependency>
 ```
+
+## Refreshing routes
+
+Every source whose locator extends `AbstractRefreshableRouteDefinitionLocator` (the `files`,
+`configserver` and `openapi` sources) caches its route definitions and reloads them:
+
+- at startup;
+- on the source's own trigger (file watch, poll interval, …);
+- on **`/actuator/refresh`** and **`/actuator/busrefresh`** (Spring Cloud Bus).
+
+The `/refresh` support is provided once, in `spring-cloud-gateway-routes-core`: a shared listener
+reloads **all** refreshable locators on `RefreshScopeRefreshedEvent`, re-reading each source from
+scratch (not just rebuilding the gateway from the cached snapshot). It is wired only when the
+Spring Cloud Config client (`spring-cloud-context`) is on the classpath — i.e. whenever the gateway
+is itself a Config Server client — and degrades gracefully otherwise. Expose the endpoints as usual:
+
+```yaml
+management.endpoints.web.exposure.include: refresh, busrefresh
+```
+
+> The `database` source is not cached (it reads on demand), so it always reflects the latest
+> state without needing this mechanism.

--- a/spring-cloud-gateway-routes/pom.xml
+++ b/spring-cloud-gateway-routes/pom.xml
@@ -17,6 +17,7 @@
 		<module>spring-cloud-gateway-routes-core</module>
 		<module>spring-cloud-gateway-routes-database</module>
 		<module>spring-cloud-gateway-routes-files</module>
+		<module>spring-cloud-gateway-routes-configserver</module>
 		<module>spring-cloud-gateway-routes-openapi</module>
 		<module>spring-cloud-gateway-routes-security</module>
 	</modules>

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/README.md
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/README.md
@@ -1,0 +1,97 @@
+# spring-cloud-gateway-routes-configserver
+
+Sources Spring Cloud Gateway route definitions from JSON and YAML files served over HTTP by a
+[Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/reference/server.html)
+and aggregates them into the route locator. Routes stay declared as files under version control
+(the Config Server backing repository), while the gateway fetches them at runtime — no redeploy
+to change routing.
+
+The files are fetched through the Config Server
+[plain-text resource endpoint](https://docs.spring.io/spring-cloud-config/reference/server/resources.html)
+(`/{name}/{profile}/{label}/{path}`), which serves the raw file content.
+
+```xml
+<dependency>
+    <groupId>ch.nexsol.gateway</groupId>
+    <artifactId>spring-cloud-gateway-routes-configserver</artifactId>
+    <version>${spring-cloud-gateway-plugins.version}</version>
+</dependency>
+```
+
+## Configuration
+
+Two complementary ways to point at the route files — use either or both:
+
+```yaml
+spring.cloud.gateway.server.webflux.routes-configserver:
+  enabled: true
+  update-interval: 30s                # optional; re-fetch every source on this fixed delay
+  # 1. Full URLs to individual route files
+  urls:
+    - http://localhost:8888/gateway/default/main/orders-routes.yaml
+    - http://localhost:8888/gateway/default/main/billing-routes.json
+  # 2. Config Server coordinates: a base "directory" + an explicit list of files
+  config-server:
+    uri: http://localhost:8888        # Config Server base URI
+    name: gateway                     # {name}    (application)
+    profile: default                  # {profile}
+    label: main                       # {label}   (optional, e.g. git branch/tag)
+    files:                            # each resolved as /{name}/{profile}/{label}/{file}
+      - routes/orders.yaml
+      - routes/billing.yaml
+```
+
+> The Config Server has **no directory-listing API**: its plain-text endpoint serves one file per
+> request. A "directory" is therefore expressed as the coordinate above plus an explicit `files`
+> list — each entry is fetched individually.
+
+A source that is transiently unreachable is logged and the previous route snapshot is kept.
+
+## Reloading
+
+The routes are re-fetched from the Config Server in these cases:
+
+- **At startup** (always).
+- **Periodically**, when `update-interval` is set.
+- **On demand** via `/actuator/refresh` and `/actuator/busrefresh` (Spring Cloud Bus). Both publish
+  a `RefreshScopeRefreshedEvent`, handled by the shared refresher in
+  [spring-cloud-gateway-routes-core](../README.md#refreshing-routes), which re-fetches every source
+  and rebuilds the gateway route table.
+
+The `/refresh` support is active only when the Spring Cloud Config client (`spring-cloud-context`)
+is on the classpath — i.e. whenever the gateway is itself a Config Server client. Expose the
+endpoints as usual:
+
+```yaml
+management.endpoints.web.exposure.include: refresh, busrefresh
+```
+
+> Note: `/refresh` and `/busrefresh` re-fetch the **content** of the configured files. The list of
+> URLs (and Config Server coordinates) is read at startup; changing that list requires a restart.
+
+## File format
+
+Each fetched file mirrors the standard `spring.cloud.gateway` route configuration and uses the
+exact same format as the [file-based locator](../spring-cloud-gateway-routes-files/README.md): a
+top-level array of routes or an object with a `routes` array, with predicates and filters in either
+the shorthand string form or the object form. The file format (JSON vs YAML) is detected from the
+URL file extension.
+
+```yaml
+routes:
+  - id: orders_route
+    uri: https://orders.example.org
+    order: 1
+    predicates:
+      - Cookie=mycookie,mycookievalue   # shorthand form
+      - name: Path                      # object form
+        args:
+          pattern: /orders/**
+    filters:
+      - AddRequestHeader=X-Request-Foo,Bar
+      - name: Retry
+        args:
+          retries: "3"
+    metadata:
+      tier: gold
+```

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/pom.xml
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/pom.xml
@@ -9,22 +9,28 @@
 		<version>${revision}</version>
 		<relativePath>../pom.xml </relativePath>
 	</parent>
-	<artifactId>spring-cloud-gateway-routes-core</artifactId>
-	<name>spring-cloud-gateway-routes-core</name>
-	<description>Shared route definition locator infrastructure for the routes plugins</description>
+	<artifactId>spring-cloud-gateway-routes-configserver</artifactId>
+	<name>spring-cloud-gateway-routes-configserver</name>
+	<description>Route definition locator sourcing JSON/YAML route files served by Spring Cloud Config Server for Spring Cloud Gateway</description>
 	<dependencies>
+		<dependency>
+			<groupId>ch.nexsol-tech.gateway</groupId>
+			<artifactId>spring-cloud-gateway-routes-core</artifactId>
+			<version>${revision}</version>
+		</dependency>
+		<!-- Reuses the JSON/YAML RouteDefinition parser shared with the file-based locator. -->
+		<dependency>
+			<groupId>ch.nexsol-tech.gateway</groupId>
+			<artifactId>spring-cloud-gateway-routes-files</artifactId>
+			<version>${revision}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
 		</dependency>
-		<!--
-			Optional: brings RefreshScopeRefreshedEvent so refreshable locators can re-load on
-			/actuator/refresh and /actuator/busrefresh. Present whenever the application uses the
-			Spring Cloud Config client; the refresh support degrades gracefully otherwise.
-		-->
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-context</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLoader.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLoader.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.nexsol.gateway.routes.configserver.RoutesConfigServerProperties.ConfigServer;
+import ch.nexsol.gateway.routes.files.RouteDefinitionFileParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Fetches JSON/YAML route files served over HTTP by a Spring Cloud Config Server and
+ * parses them into {@link RouteDefinition}. The fetch is non-blocking through
+ * {@link WebClient}; parsing reuses the format shared with the file-based locator.
+ * <p>
+ * The effective list of file URLs is the union of the explicitly configured full URLs and
+ * the URLs built from the Config Server coordinates (base URI, application name, profile,
+ * optional label) and the explicit list of files, resolved against the Config Server
+ * plain-text resource endpoint {@code /{name}/{profile}[/{label}]/{path}}.
+ */
+public class ConfigServerRouteDefinitionLoader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ConfigServerRouteDefinitionLoader.class);
+
+	private final WebClient webClient;
+
+	private final RouteDefinitionFileParser parser;
+
+	private final List<String> urls;
+
+	/**
+	 * Creates the loader.
+	 * @param webClient the client used to fetch the files
+	 * @param parser the JSON/YAML route file parser
+	 * @param properties the Config Server locator properties
+	 */
+	public ConfigServerRouteDefinitionLoader(WebClient webClient, RouteDefinitionFileParser parser,
+			RoutesConfigServerProperties properties) {
+		this.webClient = webClient;
+		this.parser = parser;
+		this.urls = resolveUrls(properties);
+	}
+
+	/**
+	 * Fetches and parses every configured route file, preserving the configured order.
+	 * @return the aggregated route definitions
+	 */
+	public Flux<RouteDefinition> load() {
+		if (this.urls.isEmpty()) {
+			LOG.warn("No Config Server route file URLs configured");
+			return Flux.empty();
+		}
+		return Flux.fromIterable(this.urls).concatMap(this::fetch);
+	}
+
+	private Flux<RouteDefinition> fetch(String url) {
+		return this.webClient.get()
+			.uri(url)
+			.retrieve()
+			.bodyToMono(byte[].class)
+			.map((body) -> parse(url, body))
+			.flatMapMany(Flux::fromIterable)
+			.onErrorMap((ex) -> !(ex instanceof RouteConfigServerException),
+					(ex) -> new RouteConfigServerException("Unable to load route file '" + url + "'", ex));
+	}
+
+	private List<RouteDefinition> parse(String url, byte[] body) {
+		return this.parser.parse(filenameOf(url), new ByteArrayInputStream(body));
+	}
+
+	/**
+	 * Builds the effective list of file URLs from the explicit URLs and the Config Server
+	 * coordinates.
+	 * @param properties the Config Server locator properties
+	 * @return the ordered, immutable list of URLs to fetch
+	 */
+	static List<String> resolveUrls(RoutesConfigServerProperties properties) {
+		List<String> resolved = new ArrayList<>(properties.getUrls());
+		ConfigServer configServer = properties.getConfigServer();
+		if (configServer != null && !configServer.getFiles().isEmpty()) {
+			resolved.addAll(buildConfigServerUrls(configServer));
+		}
+		return List.copyOf(resolved);
+	}
+
+	private static List<String> buildConfigServerUrls(ConfigServer configServer) {
+		if (!StringUtils.hasText(configServer.getUri())) {
+			throw new RouteConfigServerException(
+					"'config-server.uri' must be set when 'config-server.files' is provided");
+		}
+		if (!StringUtils.hasText(configServer.getName())) {
+			throw new RouteConfigServerException(
+					"'config-server.name' must be set when 'config-server.files' is provided");
+		}
+		String base = trimTrailingSlash(configServer.getUri());
+		String profile = StringUtils.hasText(configServer.getProfile()) ? configServer.getProfile() : "default";
+		List<String> urls = new ArrayList<>();
+		for (String file : configServer.getFiles()) {
+			StringBuilder url = new StringBuilder(base).append('/')
+				.append(configServer.getName())
+				.append('/')
+				.append(profile);
+			if (StringUtils.hasText(configServer.getLabel())) {
+				url.append('/').append(configServer.getLabel());
+			}
+			url.append('/').append(trimLeadingSlash(file));
+			urls.add(url.toString());
+		}
+		return urls;
+	}
+
+	private static String filenameOf(String url) {
+		String path = URI.create(url).getPath();
+		if (!StringUtils.hasText(path)) {
+			return url;
+		}
+		int slash = path.lastIndexOf('/');
+		return (slash >= 0) ? path.substring(slash + 1) : path;
+	}
+
+	private static String trimTrailingSlash(String value) {
+		return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+	}
+
+	private static String trimLeadingSlash(String value) {
+		return value.startsWith("/") ? value.substring(1) : value;
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLocator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+import ch.nexsol.gateway.routes.core.AbstractRefreshableRouteDefinitionLocator;
+import reactor.core.publisher.Flux;
+
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * {@link org.springframework.cloud.gateway.route.RouteDefinitionLocator} sourcing route
+ * definitions from JSON/YAML files served by a Spring Cloud Config Server. The fetch is
+ * fully non-blocking and the result is cached by the superclass.
+ */
+public class ConfigServerRouteDefinitionLocator extends AbstractRefreshableRouteDefinitionLocator {
+
+	private final ConfigServerRouteDefinitionLoader loader;
+
+	/**
+	 * Creates the locator.
+	 * @param loader the loader fetching the configured files
+	 * @param publisher the publisher used to trigger route refresh events
+	 */
+	public ConfigServerRouteDefinitionLocator(ConfigServerRouteDefinitionLoader loader,
+			ApplicationEventPublisher publisher) {
+		super(publisher);
+		this.loader = loader;
+	}
+
+	@Override
+	protected Flux<RouteDefinition> loadRouteDefinitions() {
+		return this.loader.load();
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RouteConfigServerException.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RouteConfigServerException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+/**
+ * Thrown when a route file cannot be fetched from the Config Server or the source
+ * configuration is invalid.
+ */
+public class RouteConfigServerException extends RuntimeException {
+
+	/**
+	 * Creates the exception with a message.
+	 * @param message the detail message
+	 */
+	public RouteConfigServerException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates the exception with a message and cause.
+	 * @param message the detail message
+	 * @param cause the underlying cause
+	 */
+	public RouteConfigServerException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RouteConfigServerLifecycle.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RouteConfigServerLifecycle.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+import java.time.Duration;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * Fetches the Config Server routes once the context is running and, when an update
+ * interval is configured, reloads every source on a fixed delay. Runs in the last startup
+ * phase so the gateway route infrastructure is ready before the initial refresh event is
+ * published.
+ */
+public class RouteConfigServerLifecycle implements SmartLifecycle {
+
+	private final ConfigServerRouteDefinitionLocator locator;
+
+	private final Duration updateInterval;
+
+	private volatile boolean running;
+
+	private Disposable poll;
+
+	/**
+	 * Creates the lifecycle.
+	 * @param locator the locator to refresh
+	 * @param updateInterval the fixed delay between reloads, or {@code null} to load once
+	 */
+	public RouteConfigServerLifecycle(ConfigServerRouteDefinitionLocator locator, Duration updateInterval) {
+		this.locator = locator;
+		this.updateInterval = updateInterval;
+	}
+
+	@Override
+	public void start() {
+		this.running = true;
+		// Block on the initial load so routes are available before startup completes.
+		this.locator.refresh().block();
+		if (this.updateInterval != null && !this.updateInterval.isZero() && !this.updateInterval.isNegative()) {
+			this.poll = Flux.interval(this.updateInterval, this.updateInterval)
+				.concatMap((tick) -> this.locator.refresh())
+				.subscribe();
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.running = false;
+		if (this.poll != null) {
+			this.poll.dispose();
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
+	@Override
+	public int getPhase() {
+		return Integer.MAX_VALUE;
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RoutesConfigServerProperties.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/RoutesConfigServerProperties.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the route definition locator sourcing JSON/YAML route
+ * files served over HTTP by a Spring Cloud Config Server.
+ */
+@ConfigurationProperties(prefix = "spring.cloud.gateway.server.webflux.routes-configserver")
+public class RoutesConfigServerProperties {
+
+	/**
+	 * Whether the Config Server route definition locator is enabled.
+	 */
+	private boolean enabled;
+
+	/**
+	 * Optional fixed delay between two automatic reloads of every source. When unset the
+	 * routes are fetched once at startup only.
+	 */
+	private Duration updateInterval;
+
+	/**
+	 * Full URLs pointing at individual JSON/YAML route files, typically the Config Server
+	 * plain-text resource endpoint, for example
+	 * {@code http://localhost:8888/gateway/default/main/orders-routes.yaml}.
+	 */
+	private List<String> urls = new ArrayList<>();
+
+	/**
+	 * Config Server coordinates used to build the file URLs from a base "directory" and
+	 * an explicit list of file names.
+	 */
+	private ConfigServer configServer = new ConfigServer();
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public Duration getUpdateInterval() {
+		return this.updateInterval;
+	}
+
+	public void setUpdateInterval(Duration updateInterval) {
+		this.updateInterval = updateInterval;
+	}
+
+	public List<String> getUrls() {
+		return this.urls;
+	}
+
+	public void setUrls(List<String> urls) {
+		this.urls = urls;
+	}
+
+	public ConfigServer getConfigServer() {
+		return this.configServer;
+	}
+
+	public void setConfigServer(ConfigServer configServer) {
+		this.configServer = configServer;
+	}
+
+	/**
+	 * Config Server coordinates addressing route files through the plain-text resource
+	 * endpoint ({@code /{name}/{profile}[/{label}]/{path}}). Since the Config Server has
+	 * no directory-listing API, the files are enumerated explicitly.
+	 */
+	public static class ConfigServer {
+
+		/**
+		 * Base URI of the Config Server, for example {@code http://localhost:8888}.
+		 */
+		private String uri;
+
+		/**
+		 * Application name, mapped to the {@code {name}} path segment.
+		 */
+		private String name;
+
+		/**
+		 * Profile, mapped to the {@code {profile}} path segment.
+		 */
+		private String profile = "default";
+
+		/**
+		 * Optional label (git branch/tag), mapped to the {@code {label}} path segment.
+		 */
+		private String label;
+
+		/**
+		 * File paths under the coordinate ("directory" content), each resolved against
+		 * the plain-text resource endpoint, for example {@code routes/orders.yaml}.
+		 */
+		private List<String> files = new ArrayList<>();
+
+		public String getUri() {
+			return this.uri;
+		}
+
+		public void setUri(String uri) {
+			this.uri = uri;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getProfile() {
+			return this.profile;
+		}
+
+		public void setProfile(String profile) {
+			this.profile = profile;
+		}
+
+		public String getLabel() {
+			return this.label;
+		}
+
+		public void setLabel(String label) {
+			this.label = label;
+		}
+
+		public List<String> getFiles() {
+			return this.files;
+		}
+
+		public void setFiles(List<String> files) {
+			this.files = files;
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/autoconfigure/RoutesConfigServerAutoConfiguration.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/java/ch/nexsol/gateway/routes/configserver/autoconfigure/RoutesConfigServerAutoConfiguration.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver.autoconfigure;
+
+import ch.nexsol.gateway.routes.configserver.ConfigServerRouteDefinitionLoader;
+import ch.nexsol.gateway.routes.configserver.ConfigServerRouteDefinitionLocator;
+import ch.nexsol.gateway.routes.configserver.RouteConfigServerLifecycle;
+import ch.nexsol.gateway.routes.configserver.RoutesConfigServerProperties;
+import ch.nexsol.gateway.routes.files.RouteDefinitionFileParser;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Auto-configuration wiring the Config Server-based route definition locator when
+ * {@code spring.cloud.gateway.server.webflux.routes-configserver.enabled} is
+ * {@code true}.
+ */
+@AutoConfiguration
+@ConditionalOnProperty(prefix = "spring.cloud.gateway.server.webflux.routes-configserver", name = "enabled",
+		havingValue = "true")
+@EnableConfigurationProperties(RoutesConfigServerProperties.class)
+public class RoutesConfigServerAutoConfiguration {
+
+	/**
+	 * Registers the JSON/YAML route file parser unless the application provides its own.
+	 * @return the parser bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	RouteDefinitionFileParser routeDefinitionFileParser() {
+		return new RouteDefinitionFileParser();
+	}
+
+	/**
+	 * Registers the loader fetching the configured route files. The client is derived
+	 * from the application {@link WebClient.Builder} when one is available.
+	 * @param parser the route file parser
+	 * @param properties the Config Server locator properties
+	 * @param webClientBuilder the optional application web client builder
+	 * @return the loader bean
+	 */
+	@Bean
+	ConfigServerRouteDefinitionLoader configServerRouteDefinitionLoader(RouteDefinitionFileParser parser,
+			RoutesConfigServerProperties properties, ObjectProvider<WebClient.Builder> webClientBuilder) {
+		WebClient webClient = webClientBuilder.getIfAvailable(WebClient::builder).build();
+		return new ConfigServerRouteDefinitionLoader(webClient, parser, properties);
+	}
+
+	/**
+	 * Registers the Config Server-backed route definition locator.
+	 * @param loader the Config Server loader
+	 * @param publisher the application event publisher
+	 * @return the locator bean
+	 */
+	@Bean
+	ConfigServerRouteDefinitionLocator configServerRouteDefinitionLocator(ConfigServerRouteDefinitionLoader loader,
+			ApplicationEventPublisher publisher) {
+		return new ConfigServerRouteDefinitionLocator(loader, publisher);
+	}
+
+	/**
+	 * Registers the lifecycle performing the initial fetch and optional periodic reload.
+	 * @param locator the locator to refresh
+	 * @param properties the Config Server locator properties
+	 * @return the lifecycle bean
+	 */
+	@Bean
+	RouteConfigServerLifecycle routeConfigServerLifecycle(ConfigServerRouteDefinitionLocator locator,
+			RoutesConfigServerProperties properties) {
+		return new RouteConfigServerLifecycle(locator, properties.getUpdateInterval());
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ch.nexsol.gateway.routes.configserver.autoconfigure.RoutesConfigServerAutoConfiguration

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLoaderTests.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/java/ch/nexsol/gateway/routes/configserver/ConfigServerRouteDefinitionLoaderTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.nexsol.gateway.routes.configserver.RoutesConfigServerProperties.ConfigServer;
+import ch.nexsol.gateway.routes.files.RouteDefinitionFileParser;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link ConfigServerRouteDefinitionLoader} covering URL resolution from Config
+ * Server coordinates, the reactive fetch/parse of YAML and JSON files, and error mapping.
+ */
+class ConfigServerRouteDefinitionLoaderTests {
+
+	@Test
+	void fetchesAndParsesYamlAndJsonUrlsInOrder() {
+		List<String> requested = new ArrayList<>();
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		properties.setUrls(List.of("http://config:8888/gateway/default/main/orders.yaml",
+				"http://config:8888/gateway/default/main/billing.json"));
+
+		ConfigServerRouteDefinitionLoader loader = new ConfigServerRouteDefinitionLoader(webClient(requested),
+				new RouteDefinitionFileParser(), properties);
+
+		List<RouteDefinition> definitions = loader.load().collectList().block();
+
+		assertThat(definitions).extracting(RouteDefinition::getId).containsExactly("orders_route", "billing_route");
+		assertThat(definitions.get(0).getPredicates().get(0).getName()).isEqualTo("Path");
+		assertThat(requested).containsExactly("http://config:8888/gateway/default/main/orders.yaml",
+				"http://config:8888/gateway/default/main/billing.json");
+	}
+
+	@Test
+	void resolvesConfigServerCoordinatesWithLabel() {
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		ConfigServer configServer = properties.getConfigServer();
+		configServer.setUri("http://config:8888/");
+		configServer.setName("gateway");
+		configServer.setProfile("prod");
+		configServer.setLabel("main");
+		configServer.setFiles(List.of("routes/orders.yaml", "/routes/billing.yaml"));
+
+		assertThat(ConfigServerRouteDefinitionLoader.resolveUrls(properties)).containsExactly(
+				"http://config:8888/gateway/prod/main/routes/orders.yaml",
+				"http://config:8888/gateway/prod/main/routes/billing.yaml");
+	}
+
+	@Test
+	void resolvesConfigServerCoordinatesWithoutLabelAndMergesExplicitUrls() {
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		properties.setUrls(List.of("http://elsewhere/extra.yaml"));
+		ConfigServer configServer = properties.getConfigServer();
+		configServer.setUri("http://config:8888");
+		configServer.setName("gateway");
+		configServer.setFiles(List.of("orders.yaml"));
+
+		assertThat(ConfigServerRouteDefinitionLoader.resolveUrls(properties))
+			.containsExactly("http://elsewhere/extra.yaml", "http://config:8888/gateway/default/orders.yaml");
+	}
+
+	@Test
+	void failsWhenConfigServerUriMissing() {
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		ConfigServer configServer = properties.getConfigServer();
+		configServer.setName("gateway");
+		configServer.setFiles(List.of("orders.yaml"));
+
+		assertThatExceptionOfType(RouteConfigServerException.class)
+			.isThrownBy(() -> ConfigServerRouteDefinitionLoader.resolveUrls(properties))
+			.withMessageContaining("config-server.uri");
+	}
+
+	@Test
+	void failsWhenConfigServerNameMissing() {
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		ConfigServer configServer = properties.getConfigServer();
+		configServer.setUri("http://config:8888");
+		configServer.setFiles(List.of("orders.yaml"));
+
+		assertThatExceptionOfType(RouteConfigServerException.class)
+			.isThrownBy(() -> ConfigServerRouteDefinitionLoader.resolveUrls(properties))
+			.withMessageContaining("config-server.name");
+	}
+
+	@Test
+	void returnsEmptyWhenNothingConfigured() {
+		ConfigServerRouteDefinitionLoader loader = new ConfigServerRouteDefinitionLoader(webClient(new ArrayList<>()),
+				new RouteDefinitionFileParser(), new RoutesConfigServerProperties());
+
+		StepVerifier.create(loader.load()).verifyComplete();
+	}
+
+	@Test
+	void wrapsFetchErrorInRouteConfigServerException() {
+		RoutesConfigServerProperties properties = new RoutesConfigServerProperties();
+		properties.setUrls(List.of("http://config:8888/gateway/default/main/missing.yaml"));
+		ExchangeFunction notFound = (request) -> Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+		ConfigServerRouteDefinitionLoader loader = new ConfigServerRouteDefinitionLoader(
+				WebClient.builder().exchangeFunction(notFound).build(), new RouteDefinitionFileParser(), properties);
+
+		StepVerifier.create(loader.load()).expectError(RouteConfigServerException.class).verify();
+	}
+
+	private WebClient webClient(List<String> requested) {
+		ExchangeFunction exchange = (request) -> {
+			requested.add(request.url().toString());
+			String resource = request.url().toString().endsWith(".yaml") ? "/routes/orders-routes.yaml"
+					: "/routes/billing-routes.json";
+			return Mono.just(ClientResponse.create(HttpStatus.OK)
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+				.body(read(resource))
+				.build());
+		};
+		return WebClient.builder().exchangeFunction(exchange).build();
+	}
+
+	private static String read(String resource) {
+		try (InputStream input = ConfigServerRouteDefinitionLoaderTests.class.getResourceAsStream(resource)) {
+			return new String(input.readAllBytes());
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/java/ch/nexsol/gateway/routes/configserver/autoconfigure/RoutesConfigServerAutoConfigurationTests.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/java/ch/nexsol/gateway/routes/configserver/autoconfigure/RoutesConfigServerAutoConfigurationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.configserver.autoconfigure;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import ch.nexsol.gateway.routes.configserver.ConfigServerRouteDefinitionLocator;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Auto-configuration tests wiring {@link RoutesConfigServerAutoConfiguration} end-to-end
+ * and verifying the initial fetch performed by the lifecycle against a stubbed client.
+ */
+class RoutesConfigServerAutoConfigurationTests {
+
+	private final ApplicationContextRunner runner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(RoutesConfigServerAutoConfiguration.class))
+		.withBean(WebClient.Builder.class, () -> WebClient.builder().exchangeFunction(stubExchange()));
+
+	@Test
+	void locatorIsAbsentWhenDisabled() {
+		this.runner.run((context) -> assertThat(context).doesNotHaveBean(ConfigServerRouteDefinitionLocator.class));
+	}
+
+	@Test
+	void locatorLoadsRoutesWhenEnabled() {
+		this.runner
+			.withPropertyValues("spring.cloud.gateway.server.webflux.routes-configserver.enabled=true",
+					"spring.cloud.gateway.server.webflux.routes-configserver.urls="
+							+ "http://config:8888/gateway/default/main/orders.yaml")
+			.run((context) -> {
+				assertThat(context).hasSingleBean(ConfigServerRouteDefinitionLocator.class);
+				ConfigServerRouteDefinitionLocator locator = context.getBean(ConfigServerRouteDefinitionLocator.class);
+				assertThat(locator.getRouteDefinitions().map(RouteDefinition::getId).collectList().block())
+					.containsExactly("orders_route");
+			});
+	}
+
+	private static ExchangeFunction stubExchange() {
+		return (request) -> Mono.just(ClientResponse.create(HttpStatus.OK)
+			.header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+			.body(read("/routes/orders-routes.yaml"))
+			.build());
+	}
+
+	private static String read(String resource) {
+		try (InputStream input = RoutesConfigServerAutoConfigurationTests.class.getResourceAsStream(resource)) {
+			return new String(input.readAllBytes());
+		}
+		catch (IOException ex) {
+			throw new UncheckedIOException(ex);
+		}
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/resources/routes/billing-routes.json
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/resources/routes/billing-routes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "billing_route",
+    "uri": "https://billing.example.org",
+    "predicates": [ "Path=/billing/**" ]
+  }
+]

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/resources/routes/orders-routes.yaml
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-configserver/src/test/resources/routes/orders-routes.yaml
@@ -1,0 +1,5 @@
+routes:
+  - id: orders_route
+    uri: https://orders.example.org
+    predicates:
+      - Path=/orders/**

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/java/ch/nexsol/gateway/routes/core/RefreshableRouteDefinitionLocatorRefresher.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/java/ch/nexsol/gateway/routes/core/RefreshableRouteDefinitionLocatorRefresher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.core;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.ApplicationListener;
+
+/**
+ * Re-loads every {@link AbstractRefreshableRouteDefinitionLocator} in the context when a
+ * {@link RefreshScopeRefreshedEvent} is published, so that {@code /actuator/refresh} and
+ * {@code /actuator/busrefresh} pull the latest route definitions from their source
+ * instead of rebuilding the gateway from the cached snapshot.
+ * <p>
+ * The locators are resolved lazily at event time, so this listener works regardless of
+ * the order in which the individual route source auto-configurations are applied, and is
+ * a no-op when no refreshable locator is present.
+ */
+public class RefreshableRouteDefinitionLocatorRefresher implements ApplicationListener<RefreshScopeRefreshedEvent> {
+
+	private final ObjectProvider<AbstractRefreshableRouteDefinitionLocator> locators;
+
+	/**
+	 * Creates the refresher.
+	 * @param locators the provider of refreshable locators to reload
+	 */
+	public RefreshableRouteDefinitionLocatorRefresher(
+			ObjectProvider<AbstractRefreshableRouteDefinitionLocator> locators) {
+		this.locators = locators;
+	}
+
+	@Override
+	public void onApplicationEvent(RefreshScopeRefreshedEvent event) {
+		Flux.fromStream(this.locators.orderedStream())
+			.flatMap(AbstractRefreshableRouteDefinitionLocator::refresh)
+			.subscribe();
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/java/ch/nexsol/gateway/routes/core/autoconfigure/RoutesCoreAutoConfiguration.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/java/ch/nexsol/gateway/routes/core/autoconfigure/RoutesCoreAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.core.autoconfigure;
+
+import ch.nexsol.gateway.routes.core.AbstractRefreshableRouteDefinitionLocator;
+import ch.nexsol.gateway.routes.core.RefreshableRouteDefinitionLocatorRefresher;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration shared by all route source modules. Registers the refresher that
+ * reloads every {@link AbstractRefreshableRouteDefinitionLocator} on
+ * {@code /actuator/refresh} and {@code /actuator/busrefresh}. Wired only when the Spring
+ * Cloud Config client refresh support is on the classpath.
+ */
+@AutoConfiguration
+@ConditionalOnClass(RefreshScopeRefreshedEvent.class)
+public class RoutesCoreAutoConfiguration {
+
+	/**
+	 * Registers the refresher reloading refreshable locators on a
+	 * {@link RefreshScopeRefreshedEvent}.
+	 * @param locators the provider of refreshable locators to reload
+	 * @return the refresher bean
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	RefreshableRouteDefinitionLocatorRefresher refreshableRouteDefinitionLocatorRefresher(
+			ObjectProvider<AbstractRefreshableRouteDefinitionLocator> locators) {
+		return new RefreshableRouteDefinitionLocatorRefresher(locators);
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ch.nexsol.gateway.routes.core.autoconfigure.RoutesCoreAutoConfiguration

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/test/java/ch/nexsol/gateway/routes/core/autoconfigure/RoutesCoreAutoConfigurationTests.java
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-core/src/test/java/ch/nexsol/gateway/routes/core/autoconfigure/RoutesCoreAutoConfigurationTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.routes.core.autoconfigure;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import ch.nexsol.gateway.routes.core.AbstractRefreshableRouteDefinitionLocator;
+import ch.nexsol.gateway.routes.core.RefreshableRouteDefinitionLocatorRefresher;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RoutesCoreAutoConfiguration} and the shared refresher, verifying that
+ * a {@link RefreshScopeRefreshedEvent} reloads every refreshable locator in the context.
+ */
+class RoutesCoreAutoConfigurationTests {
+
+	private final ApplicationContextRunner runner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(RoutesCoreAutoConfiguration.class));
+
+	@Test
+	void refresherIsRegisteredWhenRefreshSupportPresent() {
+		this.runner
+			.run((context) -> assertThat(context).hasSingleBean(RefreshableRouteDefinitionLocatorRefresher.class));
+	}
+
+	@Test
+	void refresherIsAbsentWhenRefreshSupportMissing() {
+		this.runner.withClassLoader(new FilteredClassLoader(RefreshScopeRefreshedEvent.class))
+			.run((context) -> assertThat(context).doesNotHaveBean(RefreshableRouteDefinitionLocatorRefresher.class));
+	}
+
+	@Test
+	void reloadsEveryLocatorOnRefreshScopeRefreshedEvent() {
+		this.runner.withUserConfiguration(LocatorsConfiguration.class).run((context) -> {
+			CountingLocator first = context.getBean("firstLocator", CountingLocator.class);
+			CountingLocator second = context.getBean("secondLocator", CountingLocator.class);
+			assertThat(first.loads()).isZero();
+			assertThat(second.loads()).isZero();
+
+			context.publishEvent(new RefreshScopeRefreshedEvent());
+
+			assertThat(first.loads()).isEqualTo(1);
+			assertThat(second.loads()).isEqualTo(1);
+		});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class LocatorsConfiguration {
+
+		@Bean
+		CountingLocator firstLocator(ApplicationEventPublisher publisher) {
+			return new CountingLocator(publisher);
+		}
+
+		@Bean
+		CountingLocator secondLocator(ApplicationEventPublisher publisher) {
+			return new CountingLocator(publisher);
+		}
+
+	}
+
+	static final class CountingLocator extends AbstractRefreshableRouteDefinitionLocator {
+
+		private final AtomicInteger loads = new AtomicInteger();
+
+		CountingLocator(ApplicationEventPublisher publisher) {
+			super(publisher);
+		}
+
+		int loads() {
+			return this.loads.get();
+		}
+
+		@Override
+		protected Flux<RouteDefinition> loadRouteDefinitions() {
+			this.loads.incrementAndGet();
+			return Flux.empty();
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-files/README.md
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-files/README.md
@@ -47,3 +47,8 @@ routes:
     metadata:
       tier: gold
 ```
+
+## Reloading
+
+Besides the optional `watch`, the routes are reloaded on `/actuator/refresh` and
+`/actuator/busrefresh` — see [Refreshing routes](../README.md#refreshing-routes).

--- a/spring-cloud-gateway-routes/spring-cloud-gateway-routes-openapi/README.md
+++ b/spring-cloud-gateway-routes/spring-cloud-gateway-routes-openapi/README.md
@@ -51,3 +51,8 @@ ignored by the gateway), while the base path comes from the contract.
   a `Method` predicate listing every HTTP method.
 
 The configured `metadata` and `filters` are applied to every generated route.
+
+## Reloading
+
+Besides the optional `update-interval`, the routes are regenerated on `/actuator/refresh` and
+`/actuator/busrefresh` — see [Refreshing routes](../README.md#refreshing-routes).

--- a/spring-cloud-gateway-samples/README.md
+++ b/spring-cloud-gateway-samples/README.md
@@ -12,6 +12,12 @@ Launch Eureka service discovery to test SCGateway Openapi discovery with service
 ### service-a
 Launch service-a: this will start a simple app with a controller.
 
+### config-server
+Launch config-server: a Spring Cloud Config Server (port `8888`) serving gateway route files from
+a native classpath repository (`config-repo/orders-routes.yaml`, `config-repo/billing-routes.yaml`).
+Check a served file with:
+`curl http://localhost:8888/gateway/default/main/orders-routes.yaml`
+
 ### gateway
 Launch gateway. 
 
@@ -38,6 +44,22 @@ To test, go to http://localhost:8181/swagger-ui.html and you should have access 
 The sample bundles the `spring-cloud-gateway-ui` shell. Go to http://localhost:8181/ui for
 the home page and its collapsible side menu. Because the routes-database plugin is on the
 classpath, a **Database routes** entry lights up automatically and leads to the management UI.
+
+#### spring-cloud-gateway-routes-configserver
+<i>For the demo, run the `config-server` sample first, then start the gateway with the `configserver` profile:</i>
+<br>
+`mvn spring-boot:run -Dspring-boot.run.profiles=configserver` (from the `gateway` module).
+<br>
+The gateway loads its route files from the Config Server (via
+[`application-configserver.yml`](gateway/src/main/resources/application-configserver.yml)) and exposes:
+
+| Url | Description |
+| --- | --- |
+| http://localhost:8181/cs-orders/get | route `configserver_orders_route` → httpbin.org |
+| http://localhost:8181/cs-billing/get | route `configserver_billing_route` → httpbin.org |
+
+Change a file in `config-server/.../config-repo/` and hit `POST http://localhost:8181/actuator/refresh`
+(or wait for `update-interval`) to reload the routes without restarting the gateway.
 
 #### spring-cloud-gateway-routes-database
 

--- a/spring-cloud-gateway-samples/config-server/pom.xml
+++ b/spring-cloud-gateway-samples/config-server/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>ch.nexsol-tech.gateway</groupId>
+		<artifactId>spring-cloud-gateway-samples</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml </relativePath>
+	</parent>
+	<artifactId>config-server</artifactId>
+	<name>config-server</name>
+	<description>Spring Cloud Config Server serving gateway route files</description>
+	<properties>
+		<java.version>25</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-config-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/spring-cloud-gateway-samples/config-server/src/main/java/ch/nexsol/configserver/sample/ConfigServerApplication.java
+++ b/spring-cloud-gateway-samples/config-server/src/main/java/ch/nexsol/configserver/sample/ConfigServerApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.configserver.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+/**
+ * Spring Cloud Config Server serving the gateway route files from a native (classpath)
+ * repository. The files are exposed through the plain-text resource endpoint
+ * ({@code /{name}/{profile}/{label}/{path}}) consumed by the
+ * {@code spring-cloud-gateway-routes-configserver} locator.
+ */
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ConfigServerApplication.class, args);
+	}
+
+}

--- a/spring-cloud-gateway-samples/config-server/src/main/resources/application.yml
+++ b/spring-cloud-gateway-samples/config-server/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+server.port: 8888
+spring:
+  application:
+    name: config-server
+  # 'native' backend serves files straight from the classpath repository below,
+  # so the sample needs no Git repository.
+  profiles:
+    active: native
+  cloud:
+    config:
+      server:
+        native:
+          search-locations: classpath:/config-repo/
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+        - health
+        - info
+logging:
+  level:
+    '[org.springframework.cloud.config]': info

--- a/spring-cloud-gateway-samples/config-server/src/main/resources/config-repo/billing-routes.yaml
+++ b/spring-cloud-gateway-samples/config-server/src/main/resources/config-repo/billing-routes.yaml
@@ -1,0 +1,11 @@
+routes:
+  - id: configserver_billing_route
+    uri: https://httpbin.org
+    predicates:
+      - Path=/cs-billing/**
+      - Method=GET
+    filters:
+      - StripPrefix=1
+    metadata:
+      source: configserver
+      domain: billing

--- a/spring-cloud-gateway-samples/config-server/src/main/resources/config-repo/orders-routes.yaml
+++ b/spring-cloud-gateway-samples/config-server/src/main/resources/config-repo/orders-routes.yaml
@@ -1,0 +1,11 @@
+routes:
+  - id: configserver_orders_route
+    uri: https://httpbin.org
+    predicates:
+      - Path=/cs-orders/**
+      - Method=GET
+    filters:
+      - StripPrefix=1
+    metadata:
+      source: configserver
+      domain: orders

--- a/spring-cloud-gateway-samples/gateway/pom.xml
+++ b/spring-cloud-gateway-samples/gateway/pom.xml
@@ -58,6 +58,11 @@
 		</dependency>
 		<dependency>
 			<groupId>ch.nexsol-tech.gateway</groupId>
+			<artifactId>spring-cloud-gateway-routes-configserver</artifactId>
+			<version>${revision}</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.nexsol-tech.gateway</groupId>
 			<artifactId>spring-cloud-gateway-routes-openapi</artifactId>
 			<version>${revision}</version>
 		</dependency>

--- a/spring-cloud-gateway-samples/gateway/src/main/resources/application-configserver.yml
+++ b/spring-cloud-gateway-samples/gateway/src/main/resources/application-configserver.yml
@@ -1,0 +1,25 @@
+# Profile-specific configuration, active only with the 'configserver' profile:
+#   mvn spring-boot:run -Dspring-boot.run.profiles=configserver
+# or: java -jar sample-gateway.jar --spring.profiles.active=configserver
+#
+# Requires the 'config-server' sample running on :8888, which serves the route files
+# (config-repo/orders-routes.yaml, config-repo/billing-routes.yaml) over its plain-text
+# resource endpoint /{name}/{profile}/{label}/{path}.
+#
+# The gateway then exposes:
+#   GET http://localhost:8181/cs-orders/**   -> https://httpbin.org (configserver_orders_route)
+#   GET http://localhost:8181/cs-billing/**  -> https://httpbin.org (configserver_billing_route)
+spring.cloud.gateway.server.webflux.routes-configserver:
+  enabled: true
+  update-interval: 30s
+  config-server:
+    uri: http://localhost:8888
+    name: gateway
+    profile: default
+    label: main
+    files:
+      - orders-routes.yaml
+      - billing-routes.yaml
+  # Alternatively, address files by full URL (either form, or both, may be used):
+  # urls:
+  #   - http://localhost:8888/gateway/default/main/orders-routes.yaml

--- a/spring-cloud-gateway-samples/pom.xml
+++ b/spring-cloud-gateway-samples/pom.xml
@@ -18,5 +18,6 @@
         <module>gateway</module>
         <module>service-a</module>
         <module>eureka</module>
+        <module>config-server</module>
     </modules>
 </project>


### PR DESCRIPTION
…e refresh

Add a new spring-cloud-gateway-routes-configserver module sourcing JSON/YAML route files served over HTTP by a Spring Cloud Config Server. Sources are configured as a list of full URLs and/or Config Server coordinates (uri/name/profile/label + explicit file list, since the Config Server has no directory-listing API). The fetch is non-blocking (WebClient) and reuses the shared JSON/YAML parser; an optional update-interval polls periodically.

Generalize the /actuator/refresh and /actuator/busrefresh support into spring-cloud-gateway-routes-core: a shared RefreshScopeRefreshedEvent listener reloads every AbstractRefreshableRouteDefinitionLocator (files, configserver, openapi), wired only when spring-cloud-context is present. Remove the configserver-specific listener that this supersedes.

Add a config-server sample serving route files from a native repository and an application-configserver.yml on the existing gateway sample, activated by the 'configserver' profile.