### PR TITLE
fix: keep the OpenAPI discovery from bringing a large registry down

### DIFF
--- a/spring-cloud-gateway-hub-openapi/README.md
+++ b/spring-cloud-gateway-hub-openapi/README.md
@@ -29,6 +29,49 @@ spring.cloud.gateway.server.webflux:
       enabled: true
 ```
 
+A service can declare where its document is, in its instance metadata, instead of letting
+the hub probe the well-known SpringDoc paths. This is one HTTP call per service instead of
+up to three, and it is worth doing on a large registry:
+
+```yaml
+eureka.instance.metadata-map.openapi_path: /v3/api-docs
+```
+
+### Sizing the discovery
+
+The gateway refreshes its routes on every discovery heartbeat, and each refresh probes the
+services it does not know about yet. The defaults below keep that cost constant whatever
+the size of the registry: on a registry holding hundreds of services, probing them all at
+once saturates the connection pool, and the probes then fail with
+`PoolAcquirePendingLimitException` or `PoolAcquireTimeoutException` while the gateway stops
+routing.
+
+```yaml
+spring.cloud.gateway.server.webflux.hub-openapi:
+  enabled: true
+  gateway-uri: http://localhost:8181
+  discovery:
+    timeout: 2s              # gives up on a service that does not answer
+    concurrency: 16          # services probed at the same time
+    max-connections: 50      # size of the pool dedicated to the probes
+    cache-ttl: 5m            # how long a probe result is remembered
+```
+
+| Setting | What it does |
+|---|---|
+| `timeout` | Bounds a single probe, connection included. Without it a service that accepts connections but never answers holds the whole route refresh, and the connection it uses. |
+| `concurrency` | Number of services probed at the same time, whatever the number of discovered services. |
+| `max-connections` | The probes use a connection pool of their own, so they never compete for the connections the gateway proxies its traffic on. |
+| `cache-ttl` | The path a document was found at &mdash; or the confirmed absence of a document &mdash; is remembered per service instance, so the next heartbeat does not probe the whole registry again. Set to `0` to probe on every refresh. |
+
+Only a service that answered has its result cached. A service that could not be reached is
+probed again on the next refresh, so a service that was down when the gateway started
+appears in the hub as soon as it comes back, without waiting for `cache-ttl`.
+
+The documents themselves are never buffered by the discovery: only the path each document
+was found at is kept, and the response body is released. The documents are fetched, and
+their `servers` section rewritten, when the Swagger UI actually asks for them.
+
 ## Aggregating statically configured OpenAPI contracts
 
 When [spring-cloud-gateway-routes-openapi](../spring-cloud-gateway-routes/spring-cloud-gateway-routes-openapi/README.md)

--- a/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/HubOpenapiProperties.java
+++ b/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/HubOpenapiProperties.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.openapi;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the OpenAPI hub.
+ */
+@ConfigurationProperties(prefix = "spring.cloud.gateway.server.webflux.hub-openapi")
+public class HubOpenapiProperties {
+
+	private final Discovery discovery = new Discovery();
+
+	public Discovery getDiscovery() {
+		return this.discovery;
+	}
+
+	/**
+	 * How the hub probes the discovered services for their OpenAPI document. The defaults
+	 * are sized so that a route refresh costs the same whether the registry holds ten
+	 * services or several hundred.
+	 */
+	public static class Discovery {
+
+		/**
+		 * Maximum time a single probe may take, connection included. Bounds the route
+		 * refresh: without it a service that accepts connections but never answers holds
+		 * the whole refresh, and the connection it uses.
+		 */
+		private Duration timeout = Duration.ofSeconds(2);
+
+		/**
+		 * Number of services probed at the same time. This is what keeps a registry
+		 * holding hundreds of services from firing hundreds of concurrent requests on
+		 * every route refresh.
+		 */
+		private int concurrency = 16;
+
+		/**
+		 * Maximum number of connections of the pool dedicated to the probes. The probes
+		 * get their own pool so they never compete for the connections the gateway
+		 * proxies its traffic on.
+		 */
+		private int maxConnections = 50;
+
+		/**
+		 * How long the path a document was found at, or the confirmed absence of a
+		 * document, is remembered per service instance. A route refresh happens on every
+		 * discovery heartbeat, so without this every heartbeat probes every service
+		 * again. Set to zero to probe on every refresh.
+		 */
+		private Duration cacheTtl = Duration.ofMinutes(5);
+
+		public Duration getTimeout() {
+			return this.timeout;
+		}
+
+		public void setTimeout(Duration timeout) {
+			this.timeout = timeout;
+		}
+
+		public int getConcurrency() {
+			return this.concurrency;
+		}
+
+		public void setConcurrency(int concurrency) {
+			this.concurrency = concurrency;
+		}
+
+		public int getMaxConnections() {
+			return this.maxConnections;
+		}
+
+		public void setMaxConnections(int maxConnections) {
+			this.maxConnections = maxConnections;
+		}
+
+		public Duration getCacheTtl() {
+			return this.cacheTtl;
+		}
+
+		public void setCacheTtl(Duration cacheTtl) {
+			this.cacheTtl = cacheTtl;
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/autoconfigure/HubApiAutoConfiguration.java
+++ b/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/autoconfigure/HubApiAutoConfiguration.java
@@ -19,6 +19,7 @@ package ch.nexsol.gateway.openapi.autoconfigure;
 import java.net.URI;
 import java.util.Set;
 
+import ch.nexsol.gateway.openapi.HubOpenapiProperties;
 import ch.nexsol.gateway.openapi.hub.OpenapiService;
 import ch.nexsol.gateway.openapi.hub.SpringDocOpenapiRoutes;
 import ch.nexsol.gateway.openapi.hub.StaticOpenapiDocsRouteLocator;
@@ -33,6 +34,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
 import org.springframework.cloud.client.discovery.composite.reactive.ReactiveCompositeDiscoveryClientAutoConfiguration;
 import org.springframework.cloud.gateway.config.conditional.ConditionalOnEnabledFilter;
@@ -53,6 +55,7 @@ import org.springframework.http.codec.ServerCodecConfigurer;
 @AutoConfiguration(after = ReactiveCompositeDiscoveryClientAutoConfiguration.class)
 @ConditionalOnProperty(name = "spring.cloud.gateway.server.webflux.hub-openapi.enabled", havingValue = "true",
 		matchIfMissing = false)
+@EnableConfigurationProperties(HubOpenapiProperties.class)
 public class HubApiAutoConfiguration {
 
 	/**
@@ -73,12 +76,13 @@ public class HubApiAutoConfiguration {
 	 * discovered service instance, only when the application actually has a discovery
 	 * client: without one the hub keeps serving the statically configured contracts.
 	 * @param discoveryClient the reactive discovery client
+	 * @param hubProperties the hub configuration, bounding the probes
 	 * @return the {@link OpenapiService} bean
 	 */
 	@Bean
 	@ConditionalOnBean(ReactiveDiscoveryClient.class)
-	OpenapiService openapiService(ReactiveDiscoveryClient discoveryClient) {
-		return new OpenapiService(discoveryClient);
+	OpenapiService openapiService(ReactiveDiscoveryClient discoveryClient, HubOpenapiProperties hubProperties) {
+		return new OpenapiService(discoveryClient, hubProperties.getDiscovery());
 	}
 
 	/**
@@ -87,13 +91,14 @@ public class HubApiAutoConfiguration {
 	 * @param discoveryClient the reactive discovery client
 	 * @param properties the discovery locator properties
 	 * @param openapiService the service used to discover OpenAPI endpoints
+	 * @param hubProperties the hub configuration, bounding the probes
 	 * @return the {@link HubDiscoveryRouteLocator} bean
 	 */
 	@Bean
 	@ConditionalOnBean(ReactiveDiscoveryClient.class)
 	HubDiscoveryRouteLocator hubDiscoveryRouteLocator(ReactiveDiscoveryClient discoveryClient,
-			DiscoveryLocatorProperties properties, OpenapiService openapiService) {
-		return new HubDiscoveryRouteLocator(discoveryClient, properties, openapiService);
+			DiscoveryLocatorProperties properties, OpenapiService openapiService, HubOpenapiProperties hubProperties) {
+		return new HubDiscoveryRouteLocator(discoveryClient, properties, openapiService, hubProperties.getDiscovery());
 	}
 
 	/**

--- a/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/OpenapiService.java
+++ b/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/OpenapiService.java
@@ -17,30 +17,36 @@
 package ch.nexsol.gateway.openapi.hub;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import ch.nexsol.gateway.openapi.HubOpenapiProperties;
+import io.netty.channel.ChannelOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
 import org.springframework.cloud.gateway.route.RouteDefinition;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * Discovers the OpenAPI documentation endpoint exposed by a discovered service instance
- * by probing the well-known SpringDoc paths and returns the fetched document along with
- * its metadata.
+ * by probing the well-known SpringDoc paths, and remembers what it found so the next
+ * route refresh does not probe the whole registry again.
  */
-public class OpenapiService {
+public class OpenapiService implements DisposableBean {
 
 	private static final Logger LOG = LoggerFactory.getLogger(OpenapiService.class);
 
@@ -51,20 +57,56 @@ public class OpenapiService {
 	 */
 	public static final String METADATA_SERVICE_INSTANCE_OPENAPI_PATH_KEY = "openapi_path";
 
+	private static final List<String> DEFAULT_PATHS = List.of("/v3/api-docs.json", "/v3/api-docs.yaml", "/v3/api-docs");
+
 	private final ReactiveDiscoveryClient discoveryClient;
 
 	private final WebClient webClient;
 
-	private final List<String> paths = List.of("/v3/api-docs.json", "/v3/api-docs.yaml", "/v3/api-docs");
+	private final ConnectionProvider connectionProvider;
+
+	private final Duration cacheTtl;
+
+	private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates a new service backed by the given discovery client, probing with the
+	 * default settings.
+	 * @param discoveryClient the reactive discovery client used to resolve service
+	 * instances
+	 */
+	public OpenapiService(ReactiveDiscoveryClient discoveryClient) {
+		this(discoveryClient, new HubOpenapiProperties.Discovery());
+	}
 
 	/**
 	 * Creates a new service backed by the given discovery client.
 	 * @param discoveryClient the reactive discovery client used to resolve service
 	 * instances
+	 * @param properties the settings bounding the probes
 	 */
-	public OpenapiService(ReactiveDiscoveryClient discoveryClient) {
+	public OpenapiService(ReactiveDiscoveryClient discoveryClient, HubOpenapiProperties.Discovery properties) {
 		this.discoveryClient = discoveryClient;
-		this.webClient = WebClient.builder().build();
+		this.cacheTtl = properties.getCacheTtl();
+		// A pool of its own: probing must never take the connections the gateway proxies
+		// its traffic on, and the default pool is sized for a handful of connections.
+		this.connectionProvider = ConnectionProvider.builder("hub-openapi-discovery")
+			.maxConnections(properties.getMaxConnections())
+			.pendingAcquireTimeout(properties.getTimeout())
+			.build();
+		HttpClient httpClient = HttpClient.create(this.connectionProvider)
+			.responseTimeout(properties.getTimeout())
+			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(properties.getTimeout().toMillis()));
+		this.webClient = WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+	}
+
+	// Visible for testing: drives the probes through a stubbed exchange, without a
+	// network stack nor a connection pool to dispose of.
+	OpenapiService(ReactiveDiscoveryClient discoveryClient, WebClient webClient, Duration cacheTtl) {
+		this.discoveryClient = discoveryClient;
+		this.webClient = webClient;
+		this.cacheTtl = cacheTtl;
+		this.connectionProvider = null;
 	}
 
 	/**
@@ -83,45 +125,151 @@ public class OpenapiService {
 			.flatMap((si) -> discoverOpenapiUrl(si, routeDefinition));
 	}
 
-	private Mono<OpenapiDiscover> discoverOpenapiUrl(ServiceInstance serviceInstance, RouteDefinition routeDefinition) {
-
-		Flux<String> paths = Flux.fromIterable(this.paths);
-		String openapiPath = serviceInstance.getMetadata().getOrDefault(METADATA_SERVICE_INSTANCE_OPENAPI_PATH_KEY, "");
-		if (StringUtils.hasText(openapiPath)) {
-			paths = Flux.just(openapiPath);
+	/**
+	 * Releases the connection pool dedicated to the probes.
+	 */
+	@Override
+	public void destroy() {
+		if (this.connectionProvider != null) {
+			this.connectionProvider.dispose();
 		}
-
-		// concatMap preserves the .json -> .yaml -> plain preference order and
-		// short-circuits on the first match (next()) instead of firing all in parallel.
-		return paths.concatMap((path) -> callOpenapi(serviceInstance.getUri(), path, routeDefinition)).next();
 	}
 
-	private Mono<OpenapiDiscover> callOpenapi(URI uri, String path, RouteDefinition routeDefinition) {
+	private Mono<OpenapiDiscover> discoverOpenapiUrl(ServiceInstance serviceInstance, RouteDefinition routeDefinition) {
+		URI uri = serviceInstance.getUri();
+
+		CacheEntry cached = lookUpCache(uri);
+		if (cached != null) {
+			return (cached.path() != null) ? Mono.just(new OpenapiDiscover(cached.path(), routeDefinition))
+					: Mono.empty();
+		}
+
+		String declaredPath = serviceInstance.getMetadata()
+			.getOrDefault(METADATA_SERVICE_INSTANCE_OPENAPI_PATH_KEY, "");
+		List<String> paths = StringUtils.hasText(declaredPath) ? List.of(declaredPath) : DEFAULT_PATHS;
+
+		// concatMap preserves the .json -> .yaml -> plain preference order and takeUntil
+		// stops at the first match, instead of firing all the probes in parallel.
+		return Flux.fromIterable(paths)
+			.concatMap((path) -> probe(uri, path, routeDefinition))
+			.takeUntil(Probe::found)
+			.collectList()
+			.flatMap((probes) -> toDiscover(uri, probes, routeDefinition));
+	}
+
+	private Mono<OpenapiDiscover> toDiscover(URI uri, List<Probe> probes, RouteDefinition routeDefinition) {
+		Probe last = probes.get(probes.size() - 1);
+		if (last.found()) {
+			cache(uri, last.path());
+			return Mono.just(new OpenapiDiscover(last.path(), routeDefinition));
+		}
+		// Only a service that answered tells us it has no document. A probe that could
+		// not reach it says nothing, and caching that would keep the service out of the
+		// hub until the entry expires, long after it came back.
+		if (probes.stream().allMatch(Probe::answered)) {
+			cache(uri, null);
+		}
+		return Mono.empty();
+	}
+
+	private Mono<Probe> probe(URI uri, String path, RouteDefinition routeDefinition) {
 		return this.webClient.get().uri(uri + path).exchangeToMono((response) -> {
-			if (response.statusCode().equals(HttpStatus.OK)) {
-				LOG.debug("url {} found for route {} : {}", uri + path, routeDefinition, response.statusCode());
-				return response.bodyToMono(byte[].class)
-					.map(ByteArrayResource::new)
-					.map((byteResource) -> new OpenapiDiscover(path, response.headers().contentType(), byteResource,
-							routeDefinition));
-			}
-			else {
-				LOG.debug("url {} not found for route {} : {}", uri + path, routeDefinition, response.statusCode());
-				return Mono.empty();
-			}
-		}).onErrorComplete();
+			boolean found = response.statusCode().equals(HttpStatus.OK);
+			LOG.debug("url {} {} for route {} : {}", uri + path, found ? "found" : "not found", routeDefinition,
+					response.statusCode());
+			// The body is released, never buffered: only the path the document was found
+			// at is used downstream, and holding every document of every service in
+			// memory
+			// on every route refresh is what brings a large registry down.
+			return response.releaseBody().thenReturn(found ? Probe.found(path) : Probe.absent(path));
+		}).onErrorResume((ex) -> {
+			LOG.debug("url {} unreachable for route {} : {}", uri + path, routeDefinition, ex.getMessage());
+			return Mono.just(Probe.failed(path));
+		});
+	}
+
+	private CacheEntry lookUpCache(URI uri) {
+		if (!this.cacheTtl.isPositive()) {
+			return null;
+		}
+		CacheEntry entry = this.cache.get(uri.toString());
+		if (entry == null) {
+			return null;
+		}
+		if (entry.expiresAt().isBefore(Instant.now())) {
+			this.cache.remove(uri.toString(), entry);
+			return null;
+		}
+		return entry;
+	}
+
+	private void cache(URI uri, String path) {
+		if (!this.cacheTtl.isPositive()) {
+			return;
+		}
+		Instant now = Instant.now();
+		// Evict what expired along the way, so the instances that left the registry do
+		// not
+		// pile up.
+		this.cache.values().removeIf((entry) -> entry.expiresAt().isBefore(now));
+		this.cache.put(uri.toString(), new CacheEntry(path, now.plus(this.cacheTtl)));
 	}
 
 	/**
 	 * Result of an OpenAPI discovery.
 	 *
 	 * @param path the path at which the OpenAPI document was found
-	 * @param contentType the content type of the OpenAPI document, if provided
-	 * @param resource the fetched OpenAPI document body
 	 * @param routeDefinition the route definition the document belongs to
 	 */
-	public record OpenapiDiscover(String path, Optional<MediaType> contentType, Resource resource,
-			RouteDefinition routeDefinition) {
+	public record OpenapiDiscover(String path, RouteDefinition routeDefinition) {
+	}
+
+	/**
+	 * Outcome of a single probe. A service that answered "not there" and a service that
+	 * could not be reached both yield no document, but only the former is worth
+	 * remembering.
+	 *
+	 * @param path the probed path
+	 * @param outcome what the probe found
+	 */
+	private record Probe(String path, Outcome outcome) {
+
+		private enum Outcome {
+
+			FOUND, ABSENT, FAILED
+
+		}
+
+		static Probe found(String path) {
+			return new Probe(path, Outcome.FOUND);
+		}
+
+		static Probe absent(String path) {
+			return new Probe(path, Outcome.ABSENT);
+		}
+
+		static Probe failed(String path) {
+			return new Probe(path, Outcome.FAILED);
+		}
+
+		boolean found() {
+			return this.outcome == Outcome.FOUND;
+		}
+
+		boolean answered() {
+			return this.outcome != Outcome.FAILED;
+		}
+
+	}
+
+	/**
+	 * What the last probing of a service instance found.
+	 *
+	 * @param path the path the document was found at, or {@code null} when the instance
+	 * confirmed it has none
+	 * @param expiresAt the instant the entry stops being trusted
+	 */
+	private record CacheEntry(String path, Instant expiresAt) {
 	}
 
 }

--- a/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/discovery/HubDiscoveryRouteLocator.java
+++ b/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/discovery/HubDiscoveryRouteLocator.java
@@ -19,6 +19,7 @@ package ch.nexsol.gateway.openapi.hub.discovery;
 import java.util.List;
 import java.util.Map;
 
+import ch.nexsol.gateway.openapi.HubOpenapiProperties;
 import ch.nexsol.gateway.openapi.hub.OpenapiService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,19 +55,34 @@ public class HubDiscoveryRouteLocator extends DiscoveryClientRouteDefinitionLoca
 
 	private final OpenapiService openapiService;
 
+	private final int concurrency;
+
 	// because it's private in DiscoveryClientRouteDefinitionLocator
 	private final String routeIdPrefix;
 
 	/**
-	 * Creates a new locator.
+	 * Creates a new locator probing with the default settings.
 	 * @param discoveryClient the reactive discovery client
 	 * @param properties the discovery locator properties
 	 * @param openapiService the service used to discover the OpenAPI endpoints
 	 */
 	public HubDiscoveryRouteLocator(ReactiveDiscoveryClient discoveryClient, DiscoveryLocatorProperties properties,
 			OpenapiService openapiService) {
+		this(discoveryClient, properties, openapiService, new HubOpenapiProperties.Discovery());
+	}
+
+	/**
+	 * Creates a new locator.
+	 * @param discoveryClient the reactive discovery client
+	 * @param properties the discovery locator properties
+	 * @param openapiService the service used to discover the OpenAPI endpoints
+	 * @param hubProperties the settings bounding the probes
+	 */
+	public HubDiscoveryRouteLocator(ReactiveDiscoveryClient discoveryClient, DiscoveryLocatorProperties properties,
+			OpenapiService openapiService, HubOpenapiProperties.Discovery hubProperties) {
 		super(discoveryClient, properties);
 		this.openapiService = openapiService;
+		this.concurrency = hubProperties.getConcurrency();
 
 		if (StringUtils.hasText(properties.getRouteIdPrefix())) {
 			this.routeIdPrefix = properties.getRouteIdPrefix();
@@ -87,6 +103,9 @@ public class HubDiscoveryRouteLocator extends DiscoveryClientRouteDefinitionLoca
 		return super.getRouteDefinitions()
 			// do not process existing api doc routes
 			.filter((route) -> !route.getId().startsWith(ROUTE_ID_PREFIX))
+			// Bounded concurrency, where flatMap would otherwise default to 256: a route
+			// refresh must cost the same whether the registry holds ten services or
+			// several hundred.
 			.flatMap((routeDefinition) -> {
 				String routeId = routeDefinition.getId().replace(this.routeIdPrefix, "");
 				// Isolate failures per route: a single unreachable/erroring service must
@@ -95,7 +114,7 @@ public class HubDiscoveryRouteLocator extends DiscoveryClientRouteDefinitionLoca
 					LOG.warn("Skipping OpenAPI discovery for route {} : {}", routeId, ex.getMessage());
 					return Mono.empty();
 				});
-			})
+			}, this.concurrency)
 			.map((openapiDiscover) -> {
 				RouteDefinition routeDefinition = openapiDiscover.routeDefinition();
 

--- a/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/OpenapiServiceTests.java
+++ b/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/OpenapiServiceTests.java
@@ -16,13 +16,32 @@
 
 package ch.nexsol.gateway.openapi.hub;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import ch.nexsol.gateway.openapi.HubOpenapiProperties;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
 import reactor.test.StepVerifier;
 
+import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
 import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,9 +50,26 @@ import static org.mockito.Mockito.when;
  */
 class OpenapiServiceTests {
 
+	private static final String JSON_URL = "http://service-a.example:8080/v3/api-docs.json";
+
+	private static final String YAML_URL = "http://service-a.example:8080/v3/api-docs.yaml";
+
+	private static final String PLAIN_URL = "http://service-a.example:8080/v3/api-docs";
+
 	private final ReactiveDiscoveryClient discoveryClient = mock(ReactiveDiscoveryClient.class);
 
-	private final OpenapiService openapiService = new OpenapiService(this.discoveryClient);
+	private final List<String> probedUrls = new CopyOnWriteArrayList<>();
+
+	private Function<String, Mono<ClientResponse>> exchange = (url) -> Mono
+		.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+
+	private final WebClient webClient = WebClient.builder().exchangeFunction((request) -> {
+		this.probedUrls.add(request.url().toString());
+		return this.exchange.apply(request.url().toString());
+	}).build();
+
+	private final OpenapiService openapiService = new OpenapiService(this.discoveryClient, this.webClient,
+			Duration.ofMinutes(5));
 
 	@Test
 	void completesEmptyWhenTheRouteHasNoInstance() {
@@ -41,6 +77,153 @@ class OpenapiServiceTests {
 
 		StepVerifier.create(this.openapiService.discoverOpenapiUrl("service-a", new RouteDefinition()))
 			.verifyComplete();
+	}
+
+	@Test
+	void probingStopsAtTheFirstPathServingTheDocument() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(url.equals(JSON_URL) ? okDocument() : notFound());
+
+		StepVerifier.create(discover())
+			.assertNext((discovered) -> assertThat(discovered.path()).isEqualTo("/v3/api-docs.json"))
+			.verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly(JSON_URL);
+	}
+
+	@Test
+	void probingFallsBackToTheNextPathWhenTheDocumentIsNotAtTheFirstOne() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(url.equals(YAML_URL) ? okDocument() : notFound());
+
+		StepVerifier.create(discover())
+			.assertNext((discovered) -> assertThat(discovered.path()).isEqualTo("/v3/api-docs.yaml"))
+			.verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL);
+	}
+
+	@Test
+	void theDeclaredMetadataPathBypassesTheProbing() {
+		givenInstance(Map.of(OpenapiService.METADATA_SERVICE_INSTANCE_OPENAPI_PATH_KEY, "/openapi/spec"));
+		this.exchange = (url) -> Mono.just(okDocument());
+
+		StepVerifier.create(discover())
+			.assertNext((discovered) -> assertThat(discovered.path()).isEqualTo("/openapi/spec"))
+			.verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly("http://service-a.example:8080/openapi/spec");
+	}
+
+	@Test
+	void theDocumentIsReleasedInsteadOfBeingBuffered() {
+		givenInstance(Map.of());
+		AtomicBoolean bodyConsumed = new AtomicBoolean();
+		DataBuffer document = DefaultDataBufferFactory.sharedInstance.wrap("{}".getBytes(StandardCharsets.UTF_8));
+		this.exchange = (url) -> Mono.just(ClientResponse.create(HttpStatus.OK)
+			.body(Flux.just(document).doOnSubscribe((subscription) -> bodyConsumed.set(true)))
+			.build());
+
+		StepVerifier.create(discover()).expectNextCount(1).verifyComplete();
+
+		// The connection is only usable again once the body has been drained, but nothing
+		// of it is kept: the discovery carries the path, never the document.
+		assertThat(bodyConsumed).isTrue();
+	}
+
+	@Test
+	void theDiscoveredPathIsNotProbedAgainWhileItIsCached() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(url.equals(PLAIN_URL) ? okDocument() : notFound());
+
+		StepVerifier.create(discover()).expectNextCount(1).verifyComplete();
+		StepVerifier.create(discover())
+			.assertNext((discovered) -> assertThat(discovered.path()).isEqualTo("/v3/api-docs"))
+			.verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL, PLAIN_URL);
+	}
+
+	@Test
+	void theAbsenceOfDocumentIsCachedWhenTheServiceAnsweredForEveryPath() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(notFound());
+
+		StepVerifier.create(discover()).verifyComplete();
+		StepVerifier.create(discover()).verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL, PLAIN_URL);
+	}
+
+	@Test
+	void anUnreachableServiceIsProbedAgainOnTheNextRefresh() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.error(new IllegalStateException("connection refused"));
+
+		StepVerifier.create(discover()).verifyComplete();
+		StepVerifier.create(discover()).verifyComplete();
+
+		// Failing to reach a service says nothing about its document: caching that would
+		// keep it out of the hub long after it came back.
+		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL, PLAIN_URL, JSON_URL, YAML_URL, PLAIN_URL);
+	}
+
+	@Test
+	void everyRefreshProbesAgainWhenTheCacheIsDisabled() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(url.equals(JSON_URL) ? okDocument() : notFound());
+		OpenapiService withoutCache = new OpenapiService(this.discoveryClient, this.webClient, Duration.ZERO);
+
+		StepVerifier.create(withoutCache.discoverOpenapiUrl("service-a", new RouteDefinition()))
+			.expectNextCount(1)
+			.verifyComplete();
+		StepVerifier.create(withoutCache.discoverOpenapiUrl("service-a", new RouteDefinition()))
+			.expectNextCount(1)
+			.verifyComplete();
+
+		assertThat(this.probedUrls).containsExactly(JSON_URL, JSON_URL);
+	}
+
+	@Test
+	void aServiceThatNeverAnswersGivesUpOnTheConfiguredTimeout() {
+		DisposableServer silentService = HttpServer.create()
+			.host("localhost")
+			.port(0)
+			.handle((request, response) -> Mono.never())
+			.bindNow();
+		HubOpenapiProperties.Discovery properties = new HubOpenapiProperties.Discovery();
+		properties.setTimeout(Duration.ofMillis(200));
+		OpenapiService service = new OpenapiService(this.discoveryClient, properties);
+		when(this.discoveryClient.getInstances("service-a"))
+			.thenReturn(Flux.just(new DefaultServiceInstance("service-a-1", "service-a", silentService.host(),
+					silentService.port(), false)));
+
+		try {
+			StepVerifier.create(service.discoverOpenapiUrl("service-a", new RouteDefinition()))
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
+		}
+		finally {
+			service.destroy();
+			silentService.disposeNow();
+		}
+	}
+
+	private void givenInstance(Map<String, String> metadata) {
+		when(this.discoveryClient.getInstances("service-a")).thenReturn(Flux
+			.just(new DefaultServiceInstance("service-a-1", "service-a", "service-a.example", 8080, false, metadata)));
+	}
+
+	private Mono<OpenapiService.OpenapiDiscover> discover() {
+		return this.openapiService.discoverOpenapiUrl("service-a", new RouteDefinition());
+	}
+
+	private ClientResponse okDocument() {
+		return ClientResponse.create(HttpStatus.OK).body("{\"openapi\":\"3.0.1\"}").build();
+	}
+
+	private ClientResponse notFound() {
+		return ClientResponse.create(HttpStatus.NOT_FOUND).build();
 	}
 
 }

--- a/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/discovery/HubDiscoveryRouteLocatorTests.java
+++ b/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/discovery/HubDiscoveryRouteLocatorTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.nexsol.gateway.openapi.hub.discovery;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import ch.nexsol.gateway.openapi.HubOpenapiProperties;
+import ch.nexsol.gateway.openapi.hub.OpenapiService;
+import ch.nexsol.gateway.openapi.hub.OpenapiService.OpenapiDiscover;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient;
+import org.springframework.cloud.gateway.discovery.DiscoveryLocatorProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link HubDiscoveryRouteLocator}.
+ */
+class HubDiscoveryRouteLocatorTests {
+
+	private final ReactiveDiscoveryClient discoveryClient = mock(ReactiveDiscoveryClient.class);
+
+	private final OpenapiService openapiService = mock(OpenapiService.class);
+
+	@Test
+	void probesNoMoreServicesAtOnceThanConfigured() {
+		List<String> services = IntStream.rangeClosed(1, 60).mapToObj((i) -> "service-" + i).toList();
+		given(this.discoveryClient.getServices()).willReturn(Flux.fromIterable(services));
+		given(this.discoveryClient.getInstances(anyString())).willAnswer((invocation) -> {
+			String serviceId = invocation.getArgument(0);
+			return Flux
+				.just(new DefaultServiceInstance(serviceId + "-1", serviceId, serviceId + ".example", 8080, false));
+		});
+
+		AtomicInteger inFlight = new AtomicInteger();
+		AtomicInteger highWaterMark = new AtomicInteger();
+		// doOnTerminate, not doFinally: the count has to drop before flatMap sees the
+		// completion, or the next probe counts as overlapping the one that just ended.
+		given(this.openapiService.discoverOpenapiUrl(anyString(), any())).willAnswer((invocation) -> Mono.defer(() -> {
+			highWaterMark.accumulateAndGet(inFlight.incrementAndGet(), Math::max);
+			return Mono.delay(Duration.ofMillis(20)).then(Mono.<OpenapiDiscover>empty());
+		}).doOnTerminate(inFlight::decrementAndGet));
+
+		HubOpenapiProperties.Discovery properties = new HubOpenapiProperties.Discovery();
+		properties.setConcurrency(4);
+		HubDiscoveryRouteLocator locator = new HubDiscoveryRouteLocator(this.discoveryClient,
+				new DiscoveryLocatorProperties(), this.openapiService, properties);
+
+		StepVerifier.create(locator.getRouteDefinitions()).verifyComplete();
+
+		// Without the bound, flatMap would probe all 60 services at once -- and 150 of
+		// them just as happily, which is what saturates the connection pool.
+		assertThat(highWaterMark).hasValueBetween(2, 4);
+	}
+
+}


### PR DESCRIPTION
Enabling the hub against a registry holding hundreds of services froze the gateway and flooded the logs with connection pool errors. Every route refresh, which happens on every discovery heartbeat, probed every service again: the flatMap ran at its default concurrency of 256, over the shared connection pool sized at max(cores, 8) * 2, with no timeout, and buffered every document it found only to read the path it was served at.

The probes now run on a pool of their own, bounded in number, give up on the configured timeout, release the documents instead of buffering them, and remember per instance what the last probe found. Only a service that answered has its result cached: one that could not be reached is probed again on the next refresh, so it appears in the hub as soon as it comes back.

OpenapiDiscover no longer carries the document or its content type; nothing ever read them.