### PR TITLE
docs: state what the code does rather than what was chosen

### DIFF
--- a/spring-cloud-gateway-samples/gateway/gateway-filters/README.md
+++ b/spring-cloud-gateway-samples/gateway/gateway-filters/README.md
@@ -44,9 +44,9 @@ sample, whose route asks for a bare `READ`.
 
 ## Recaptcha
 
-The fourth filter of the plugin needs a secret key issued by Google, so the sample declares
-the route commented out in [`application.yml`](src/main/resources/application.yml) rather
-than shipping one that cannot answer.
+The fourth filter of the plugin needs a secret key issued by Google. Its route sits
+commented out in [`application.yml`](src/main/resources/application.yml): uncomment it and
+fill in your own key.
 
 Before enabling it, note that the filter denies with `403` on **every** outcome that is
 not a verified token — a missing token, a rejected one, a score below the threshold, and a

--- a/spring-cloud-gateway-samples/gateway/gateway-ui/README.md
+++ b/spring-cloud-gateway-samples/gateway/gateway-ui/README.md
@@ -40,7 +40,7 @@ what answers *which configuration actually won* — see
 
 ## The two refresh actions
 
-They are named after what they refresh, because they aim at different things:
+Each one aims at something different:
 
 - **Refresh view** re-reads the sources and re-renders the table. This page only.
 - **Rebuild gateway routes** publishes a `RefreshRoutesEvent`, so the route table used to

--- a/spring-cloud-gateway-ui/README.md
+++ b/spring-cloud-gateway-ui/README.md
@@ -25,8 +25,8 @@ The plugin auto-configures itself; no extra setup is required. Start the gateway
 * **Thin scrollbar** &mdash; the menu scrolls independently with a slim scrollbar.
 * **Home page** &mdash; the overview of the gateway, rendered inside the shell.
 * **Remembered controls** &mdash; the switches and drop-downs of a view are restored as they
-  were last left. Search boxes are not: a forgotten query hiding every row reads as an empty
-  view.
+  were last left. Search boxes are not: a query kept across page loads would hide rows
+  without the reader knowing why.
 
 Built with Thymeleaf, Bootstrap, HTMX and plain CSS/JS, served as static resources (no
 CDN, offline friendly).
@@ -101,8 +101,7 @@ definitions do reach the route table; the lowest order is matched first.
 
 **Filter** &mdash; the search box narrows the table on route id, target or source.
 
-**The two actions have different targets**, which is why they are named after what they
-refresh:
+**The two actions have different targets**, each named after what it refreshes:
 
 | | Refresh view | Rebuild gateway routes |
 | --- | --- | --- |
@@ -131,8 +130,8 @@ The verdict comes from the route table itself: the routes are read from the `Rou
 and each one is evaluated with the very predicates the gateway would apply, in the very
 order it applies them. The first match wins, as it does at runtime.
 
-Each candidate is then broken down **predicate by predicate**, which is what turns a bare
-"no match" into an answer:
+Each candidate is then broken down **predicate by predicate**, so a bare "no match" comes
+with the reason:
 
 ```
 ✗ no match   alpha → http://alpha.example.com        Properties   order 0
@@ -200,8 +199,8 @@ axis options and the question built on them &mdash; for reading the traffic as p
 server-side health. A metric selection pointing at a hidden column falls back rather than
 plotting what was just removed.
 
-**Map** &mdash; one bubble per route (ECharts, vendored locally). Rather than exposing raw
-axes, the chart answers a named question that also picks the metrics:
+**Map** &mdash; one bubble per route (ECharts, vendored locally). The chart is driven by a
+named question, which picks the metrics of both axes:
 
 | Question | Reads as |
 | --- | --- |
@@ -250,8 +249,8 @@ spring.cloud.gateway.server.webflux.metrics:
     - .*_healthcheck
 ```
 
-An empty list shows every route. A malformed expression is dropped with a warning rather
-than failing the application &mdash; losing a filter beats a gateway that does not start.
+An empty list shows every route. A malformed expression is dropped with a warning and the
+application still starts.
 
 The exclusion applies to the whole view: the summary, the map, the table and the traffic
 figures on the home page all read the same filtered set.
@@ -320,11 +319,11 @@ paths, it does not assume `/v3/api-docs`.
 **Vendor extensions** &mdash; Scalar renders the extensions it knows about (`x-internal`,
 `x-displayName`, `x-badges`, `x-codeSamples`, `x-tagGroups`, the `x-enum*` family, `x-example`,
 `x-scalar-*`) and drops the others, so what a service documents of its own &mdash; the roles a
-resource requires, the version it appeared in &mdash; is never displayed. A Scalar plugin
-takes those over. The contracts are left untouched: Scalar fetches only the one on
-screen and parses it itself, YAML included.
+resource requires, the version it appeared in &mdash; would not be displayed. A Scalar plugin
+renders those, from the mapping declared below. The contracts themselves are handed to Scalar
+by URL: it fetches only the one on screen and parses it, YAML included.
 
-Each extension is declared with the label it reads under, the plugin registry matching an
+Each extension is declared with the label it reads under, and the plugin registry matches an
 extension by its exact name:
 
 ```yaml

--- a/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/openapi/OpenapiViewController.java
+++ b/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/openapi/OpenapiViewController.java
@@ -51,7 +51,7 @@ public class OpenapiViewController {
 	 * <p>
 	 * The properties are resolved through a provider: an application component-scanning
 	 * this package picks the controller up outside the auto-configuration that binds
-	 * them, and a view with no declared extension is preferable to a context that fails.
+	 * them, and the view then renders with no declared extension instead of failing.
 	 * @param apiDocsPath the SpringDoc documentation path
 	 * @param properties the provider over the OpenAPI view properties
 	 */

--- a/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/openapi/OpenapiViewProperties.java
+++ b/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/openapi/OpenapiViewProperties.java
@@ -40,7 +40,7 @@ public class OpenapiViewProperties {
 
 	/**
 	 * Returns the extensions to show, keyed by extension name.
-	 * @return the labels, keyed by extension name
+	 * @return the extensions to show, keyed by extension name
 	 */
 	public Map<String, String> getExtensions() {
 		return this.extensions;

--- a/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/routes/RouteInventoryController.java
+++ b/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/routes/RouteInventoryController.java
@@ -56,9 +56,9 @@ public class RouteInventoryController {
 	}
 
 	/**
-	 * Renders the route table fragment, used to refresh the list in place. It re-reads
-	 * the sources rather than serving the cached inventory, which is what the action asks
-	 * for.
+	 * Renders the route table fragment, used to refresh the list in place: it re-reads
+	 * the sources instead of serving the cached inventory, so the figures it shows are
+	 * the current ones.
 	 * @param model the view model
 	 * @return the table fragment view name
 	 */

--- a/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-audit.js
+++ b/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-audit.js
@@ -164,8 +164,9 @@
 		live(sel('ga-live').checked);
 	});
 
-	// Restored before the first load, which reads them. The search box is left out: a
-	// forgotten query hiding every row reads as an empty audit trail.
+	// Restored before the first load, which reads them. The search box is not remembered:
+	// a query kept across page loads would hide every row and read as an empty audit
+	// trail.
 	['ga-status', 'ga-live'].forEach(function (id) {
 		window.gatewayUi.remember(sel(id));
 	});

--- a/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-openapi.js
+++ b/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-openapi.js
@@ -8,8 +8,8 @@
  * exactly as the reader left it. When the hub aggregated nothing, the contract of the
  * gateway itself is shown, so the view is never empty for no reason.
  *
- * Scalar receives the addresses of the contracts rather than their content, so it fetches
- * and parses only the one on screen, whichever format it is served in.
+ * Scalar is handed the addresses of the contracts, so it fetches and parses only the one
+ * on screen, whichever format it is served in.
  *
  * The vendor extensions Scalar does not know about are rendered by a plugin, from the
  * mapping of extension name to label the page carries. The plugin registry matches an
@@ -60,9 +60,9 @@
 	/**
 	 * The component Scalar renders for one extension.
 	 *
-	 * The value comes from the attributes rather than from a declared prop, since Vue
-	 * camel-cases prop names and `x-roles` would be looked up as `xRoles`. The render
-	 * function returns a string because the standalone bundle ships no template compiler.
+	 * The value is read off the attributes: Vue camel-cases declared prop names, so
+	 * `x-roles` would be looked up as `xRoles`. The render function returns a string
+	 * because the standalone bundle ships no template compiler.
 	 */
 	function extensionComponent(name, label) {
 		return {
@@ -73,7 +73,7 @@
 		};
 	}
 
-	/** Scalar calls the plugin to build it, hence a factory rather than an object. */
+	/** Scalar builds the plugin by calling it, so the registry is handed this factory. */
 	function extensionsPlugin() {
 		return {
 			name: 'gateway-ui-extensions',
@@ -85,8 +85,8 @@
 
 	function configuration(sources) {
 		return {
-			// The agent flag is read off the active source, hence set on each of them as
-			// well as on the page.
+			// The agent flag is read off the active source, so it is set on each of them
+			// as well as on the page.
 			sources: sources.map(function (source) {
 				return Object.assign({ agent: { disabled: true } }, source);
 			}),
@@ -97,7 +97,7 @@
 			hideDarkModeToggle: true,
 			// Scalar enables its AI agent by itself when the page is served from localhost.
 			// Its control is a form next to the search box, and it captures the clicks of
-			// its own area; this console reaches no third party anyway.
+			// its own area.
 			agent: { disabled: true },
 			// On by default. The gateway this console documents may be the only host it is
 			// allowed to reach.

--- a/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-ui.js
+++ b/spring-cloud-gateway-ui/src/main/resources/static/js/gateway-ui.js
@@ -2,8 +2,8 @@
  * Gateway UI shell behaviour: toggle the side menu between the expanded (icon + label)
  * and collapsed (icon only) states, and remember the choice across page loads.
  *
- * It also exposes the helper the views remember their own controls with, so where that
- * state lives is decided once, here.
+ * It also exposes the helper the views remember their own controls with, which is where
+ * that state is written and read.
  */
 
 /**
@@ -37,8 +37,8 @@ window.gatewayUi = (function () {
 			else {
 				var shipped = element.value;
 				element.value = stored;
-				// A stored option that no longer exists would leave the control empty:
-				// fall back on the default rather than on nothing.
+				// A stored option that no longer exists leaves the control empty: the
+				// default it was rendered with is put back.
 				if (element.value !== stored) {
 					element.value = shipped;
 				}


### PR DESCRIPTION
Comments and README prose that argued for a decision, or only made sense against the previous implementation, now describe the behaviour itself. No code change.