### PR TITLE
perf: keep reading the route sources off the page render path

### DIFF
--- a/spring-cloud-gateway-hub-openapi/README.md
+++ b/spring-cloud-gateway-hub-openapi/README.md
@@ -70,6 +70,12 @@ Only a service that answered has its result cached. A service that could not be 
 probed again on the next refresh, so a service that was down when the gateway started
 appears in the hub as soon as it comes back, without waiting for `cache-ttl`.
 
+Probing an instance stops at the first path it could not be reached on, instead of trying
+the remaining ones: they lead to the same instance and fail the same way. An unreachable
+service therefore costs one `timeout`, not one per candidate path &mdash; which is what
+keeps the few services that are always down or draining in a large registry from dominating
+the refresh.
+
 The documents themselves are never buffered by the discovery: only the path each document
 was found at is kept, and the response body is released. The documents are fetched, and
 their `servers` section rewritten, when the Swagger UI actually asks for them.

--- a/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/OpenapiService.java
+++ b/spring-cloud-gateway-hub-openapi/src/main/java/ch/nexsol/gateway/openapi/hub/OpenapiService.java
@@ -150,9 +150,12 @@ public class OpenapiService implements DisposableBean {
 
 		// concatMap preserves the .json -> .yaml -> plain preference order and takeUntil
 		// stops at the first match, instead of firing all the probes in parallel.
+		// A probe that could not reach the instance stops the sequence too: the remaining
+		// paths fail the same way, each costing another full timeout, so an unreachable
+		// service costs one timeout rather than one per candidate path.
 		return Flux.fromIterable(paths)
 			.concatMap((path) -> probe(uri, path, routeDefinition))
-			.takeUntil(Probe::found)
+			.takeUntil((probe) -> probe.found() || !probe.answered())
 			.collectList()
 			.flatMap((probes) -> toDiscover(uri, probes, routeDefinition));
 	}

--- a/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/OpenapiServiceTests.java
+++ b/spring-cloud-gateway-hub-openapi/src/test/java/ch/nexsol/gateway/openapi/hub/OpenapiServiceTests.java
@@ -165,7 +165,35 @@ class OpenapiServiceTests {
 
 		// Failing to reach a service says nothing about its document: caching that would
 		// keep it out of the hub long after it came back.
-		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL, PLAIN_URL, JSON_URL, YAML_URL, PLAIN_URL);
+		assertThat(this.probedUrls).containsExactly(JSON_URL, JSON_URL);
+	}
+
+	@Test
+	void probingStopsAtTheFirstPathTheInstanceCouldNotBeReachedOn() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.error(new IllegalStateException("connection refused"));
+
+		StepVerifier.create(discover()).verifyComplete();
+
+		// The remaining paths lead to the same instance and would fail the same way, each
+		// costing another full timeout. With a registry holding hundreds of services,
+		// that is the difference between one timeout per unreachable service and one per
+		// candidate path.
+		assertThat(this.probedUrls).containsExactly(JSON_URL);
+	}
+
+	@Test
+	void aPathTheInstanceAnsweredForDoesNotStopTheProbing() {
+		givenInstance(Map.of());
+		this.exchange = (url) -> Mono.just(url.equals(PLAIN_URL) ? okDocument() : notFound());
+
+		StepVerifier.create(discover())
+			.assertNext((discovered) -> assertThat(discovered.path()).isEqualTo("/v3/api-docs"))
+			.verifyComplete();
+
+		// A 404 is an answer: the instance is reachable and the next path is worth
+		// trying.
+		assertThat(this.probedUrls).containsExactly(JSON_URL, YAML_URL, PLAIN_URL);
 	}
 
 	@Test

--- a/spring-cloud-gateway-ui/README.md
+++ b/spring-cloud-gateway-ui/README.md
@@ -79,13 +79,20 @@ Each source is queried individually instead of through the gateway's aggregate, 
 source name is derived from the locator class name, so a locator contributed by any plugin
 shows up correctly without this module knowing about it.
 
-The inventory is **read once and cached** until a `RefreshRoutesEvent` signals a route
-change, which is when the gateway queries its own locators. Navigating between this page and
-the home page therefore queries nothing, and a locator that reaches the network &mdash;
-service discovery, a remote contract &mdash; is not called again on every page load. Each
-source is given five seconds to answer; past that it is dropped from the snapshot with a
-warning, as a source that fails to be read is, so one unreachable source cannot hold the
-page.
+The inventory is **read once, then served while it is refreshed**. Only the very first
+reader waits on the sources; a `RefreshRoutesEvent` marks the snapshot stale instead of
+dropping it, and the read it triggers runs in the background. Navigating between this page
+and the home page therefore queries nothing, and a locator that reaches the network &mdash;
+service discovery, a remote contract &mdash; is never called in the middle of a page render.
+This matters behind a discovery client: a refresh event arrives on every heartbeat, so a
+snapshot dropped on each event would leave every view paying for a full read of a registry
+holding hundreds of services. The page then shows the inventory as of the previous read; the
+*Refresh view* action is what waits for a current one.
+
+A refresh already in flight is shared rather than started again, so several views opened at
+once cost one read. Each source is given five seconds to answer; past that it is dropped
+from the snapshot with a warning, as a source that fails to be read is, so one unreachable
+source cannot hold the page.
 
 **Columns** &mdash; route (its id, with the target it resolves to under it), source, order,
 predicates and filters. A predicate or filter is rendered the way it was declared, not as a

--- a/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/routes/RouteInventoryService.java
+++ b/spring-cloud-gateway-ui/src/main/java/ch/nexsol/gateway/ui/routes/RouteInventoryService.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -49,10 +50,11 @@ import org.springframework.util.ClassUtils;
  * route visible: properties, database, files, OpenAPI contracts, Config Server or any
  * third-party source contributed to the context.
  * <p>
- * The resulting snapshot is cached until the gateway signals a route change, the same way
- * the gateway itself only queries its locators on a {@link RefreshRoutesEvent}: a locator
- * is free to reach the network on every call, and the views built on this inventory are
- * rendered on every page load.
+ * The resulting snapshot is cached and served while it is refreshed, the same way the
+ * gateway itself only queries its locators on a {@link RefreshRoutesEvent}: a locator is
+ * free to reach the network on every call, and the views built on this inventory are
+ * rendered on every page load. A {@link RefreshRoutesEvent} therefore marks the snapshot
+ * stale instead of dropping it, and the read it triggers runs in the background.
  */
 public class RouteInventoryService implements ApplicationListener<RefreshRoutesEvent> {
 
@@ -84,6 +86,18 @@ public class RouteInventoryService implements ApplicationListener<RefreshRoutesE
 	private final AtomicReference<Mono<List<RouteView>>> snapshot = new AtomicReference<>();
 
 	/**
+	 * Last inventory resolved in full. It is what every view is served from while a
+	 * refresh runs, so a page render never waits on a read of every source.
+	 */
+	private final AtomicReference<List<RouteView>> lastKnown = new AtomicReference<>();
+
+	/**
+	 * Set when the gateway signalled a route change. The next reader consumes it to
+	 * trigger a single background refresh, so a burst of refresh events costs one read.
+	 */
+	private final AtomicBoolean stale = new AtomicBoolean();
+
+	/**
 	 * Creates the service over every route definition source in the context.
 	 * @param locators the provider over every {@link RouteDefinitionLocator} bean
 	 * @param publisher the publisher used to ask the gateway to rebuild its route table
@@ -97,35 +111,71 @@ public class RouteInventoryService implements ApplicationListener<RefreshRoutesE
 	 * Collects the route definitions of every source, in locator order, flagging the ids
 	 * declared by more than one source.
 	 * <p>
-	 * The snapshot is read once and shared by every reader until a
-	 * {@link RefreshRoutesEvent} drops it, so displaying a view never re-queries the
-	 * sources.
+	 * Only the very first reader waits on the sources. Afterwards the last resolved
+	 * inventory is served straight away and a {@link RefreshRoutesEvent} merely marks it
+	 * stale, so the read that follows runs in the background rather than in the middle of
+	 * a page render. A locator backed by service discovery re-reads the registry, and
+	 * probes it, on every call; with a few hundred services that read outlasts any
+	 * acceptable page load, and refresh events arrive on every discovery heartbeat, so a
+	 * snapshot dropped on each event would leave every view paying for a full read.
 	 * @return the resolved routes, source by source
 	 */
 	public Mono<List<RouteView>> routes() {
-		return Mono.defer(() -> this.snapshot.updateAndGet((cached) -> (cached != null) ? cached : readSources()));
+		return Mono.defer(() -> {
+			List<RouteView> known = this.lastKnown.get();
+			if (known == null) {
+				return read();
+			}
+			if (this.stale.compareAndSet(true, false)) {
+				revalidate();
+			}
+			return Mono.just(known);
+		});
 	}
 
 	/**
-	 * Re-reads every source, dropping the cached snapshot first. This is what the
-	 * <em>Refresh view</em> action asks for, as opposed to merely displaying a view.
+	 * Re-reads every source, dropping the cached snapshot first, and waits for the
+	 * result. This is what the <em>Refresh view</em> action asks for, as opposed to
+	 * merely displaying a view.
 	 * @return the freshly resolved routes, source by source
 	 */
 	public Mono<List<RouteView>> refreshedRoutes() {
 		return Mono.defer(() -> {
 			this.snapshot.set(null);
-			return routes();
+			this.stale.set(false);
+			return read();
 		});
 	}
 
 	/**
-	 * Drops the cached snapshot whenever the gateway rebuilds its route table, so the
-	 * next reader sees the routes the gateway just resolved.
+	 * Marks the inventory stale whenever the gateway rebuilds its route table, so the
+	 * next reader triggers a background read and later views see the routes the gateway
+	 * just resolved. The current inventory is kept in place: dropping it would make the
+	 * next page render wait on every source.
 	 * @param event the route refresh event
 	 */
 	@Override
 	public void onApplicationEvent(RefreshRoutesEvent event) {
 		this.snapshot.set(null);
+		this.stale.set(true);
+	}
+
+	/**
+	 * Subscribes to a read whose result later views are served from, without holding the
+	 * caller. Failures are logged only: the previous inventory stays in place.
+	 */
+	private void revalidate() {
+		read().subscribe((refreshed) -> LOG.debug("Refreshed the route inventory in the background: {} route(s)",
+				refreshed.size()), (ex) -> LOG.warn("Background route inventory refresh failed", ex));
+	}
+
+	/**
+	 * Reads every source, sharing a read already in flight rather than starting a second
+	 * one: a view opened while a refresh runs must not double the load on the sources.
+	 * @return the resolved routes
+	 */
+	private Mono<List<RouteView>> read() {
+		return this.snapshot.updateAndGet((cached) -> (cached != null) ? cached : readSources());
 	}
 
 	private Mono<List<RouteView>> readSources() {
@@ -138,6 +188,7 @@ public class RouteInventoryService implements ApplicationListener<RefreshRoutesE
 			.flatMapSequential(this::readSource)
 			.collectList()
 			.map(RouteInventoryService::flagDuplicates)
+			.doOnNext(this.lastKnown::set)
 			.cache();
 	}
 

--- a/spring-cloud-gateway-ui/src/test/java/ch/nexsol/gateway/ui/routes/RouteInventoryServiceTests.java
+++ b/spring-cloud-gateway-ui/src/test/java/ch/nexsol/gateway/ui/routes/RouteInventoryServiceTests.java
@@ -159,6 +159,41 @@ class RouteInventoryServiceTests {
 	}
 
 	@Test
+	void servesThePreviousInventoryInsteadOfWaitingOnTheSourcesAgain() {
+		// A source that stopped answering must not hold the page: behind service
+		// discovery, reading the sources outlasts what a page load can wait for.
+		RouteInventoryService service = serviceOver(new SilentAfterFirstReadRouteDefinitionLocator());
+
+		StepVerifier.create(service.routes()).expectNextCount(1).verifyComplete();
+		service.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		StepVerifier.create(service.routes())
+			.assertNext((routes) -> assertThat(routes).extracting(RouteView::routeId).containsExactly("counted"))
+			.expectComplete()
+			// Well inside the bound a single source is given to answer: the view was
+			// served from the previous inventory, not from the read it just triggered.
+			.verify(Duration.ofSeconds(1));
+	}
+
+	@Test
+	void readsTheSourcesOnceForABurstOfRefreshEvents() {
+		CountingRouteDefinitionLocator locator = new CountingRouteDefinitionLocator();
+		RouteInventoryService service = serviceOver(locator);
+
+		StepVerifier.create(service.routes()).expectNextCount(1).verifyComplete();
+		service.onApplicationEvent(new RefreshRoutesEvent(this));
+		service.onApplicationEvent(new RefreshRoutesEvent(this));
+		service.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		StepVerifier.create(service.routes()).expectNextCount(1).verifyComplete();
+		StepVerifier.create(service.routes()).expectNextCount(1).verifyComplete();
+
+		// A discovery heartbeat publishes a refresh event on every tick: a burst of them
+		// costs one read, not one per event nor one per view rendered.
+		assertThat(locator.reads()).isEqualTo(2);
+	}
+
+	@Test
 	void refreshingTheViewReadsTheSourcesAgain() {
 		CountingRouteDefinitionLocator locator = new CountingRouteDefinitionLocator();
 		RouteInventoryService service = serviceOver(locator);
@@ -292,6 +327,22 @@ class RouteInventoryServiceTests {
 		@Override
 		public Flux<RouteDefinition> getRouteDefinitions() {
 			return Flux.never();
+		}
+
+	}
+
+	/**
+	 * Answers the first read, then never answers again, as a source whose registry became
+	 * unreachable does.
+	 */
+	private static final class SilentAfterFirstReadRouteDefinitionLocator implements RouteDefinitionLocator {
+
+		private final AtomicInteger reads = new AtomicInteger();
+
+		@Override
+		public Flux<RouteDefinition> getRouteDefinitions() {
+			return Flux.defer(() -> (this.reads.getAndIncrement() == 0)
+					? Flux.just(definition("counted", "http://counted")) : Flux.never());
 		}
 
 	}


### PR DESCRIPTION
With a few hundred services behind a discovery client, opening Home or Routes took upwards of 30 seconds. Both views converge on RouteInventoryService.routes(), and two things made every click pay for a full read of every source.

The inventory cache never served. A RefreshRoutesEvent dropped the snapshot, and behind a discovery client that event arrives on every heartbeat, so the snapshot never survived between two clicks. It is now marked stale instead of dropped: the reader is served the last resolved inventory straight away and triggers a single background read, and a read already in flight is shared rather than started again. Refresh view keeps waiting for a current inventory, which is what it is for.

Probing an unreachable instance cost one timeout per candidate path. takeUntil only stopped on a document being found, so a service that could not be reached was still tried on .yaml and on the plain path, which fail the same way. It now stops on the first probe that got no answer; a 404 still counts as an answer and lets the probing continue.

Neither behaviour was measured in a live registry, so the page size (routes rendered per service, unpaginated) remains the next suspect if the latency persists.